### PR TITLE
feat: add 'get-openapi-spec' to Taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,12 +8,16 @@ tasks:
     cmds:
       - find . -type f -name '*.go' -exec sed -zi 's/(?<== `\s+)"\n\+\t"/"\n"/g' {} +
       - goimports -local "github.com/aiven/go-client-codegen" -w .
+  get-openapi-spec:
+    cmds:
+      - curl -s -o openapi.json https://api.aiven.io/doc/openapi.json
   go-generate:
     cmds:
       - rm -rf {{.GEN_OUT_DIR}}
       - GEN_OUT_DIR={{.GEN_OUT_DIR}} go run -tags=generator ./generator/...
   generate:
     cmds:
+      - task: get-openapi-spec
       - task: go-generate
       - task: fmt-imports
   test:


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->

# Fill the pull request form below and remove this heading

## About this change - What it does

Adds `get-openapi-spec` to download openapi.json

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->

## Why this way

Makes it easier to run `generate`.

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
