### PR TITLE
fix: time unmarshalling

### DIFF
--- a/generator/main.go
+++ b/generator/main.go
@@ -315,6 +315,7 @@ func exec() error {
 			}
 
 			ifErr := jen.If(jen.Err().Op("!=").Nil()).Block(returnErr)
+
 			if rsp == nil {
 				block = append(block, jen.Return(jen.Err()))
 			} else {

--- a/generator/models.go
+++ b/generator/models.go
@@ -204,8 +204,9 @@ func (s *Schema) init(doc *Doc, scope map[string]*Schema, name string) {
 
 	if s.Type == SchemaTypeString {
 		parts := strings.Split(s.name, "_")
-		switch parts[len(parts)-1] {
-		case "at", "time":
+		suffix := parts[len(parts)-1]
+
+		if len(parts) > 1 && (suffix == "at" || suffix == "time") {
 			s.Type = SchemaTypeTime
 		}
 	}

--- a/handler/project/project.go
+++ b/handler/project/project.go
@@ -365,12 +365,12 @@ type EndOfLifeExtensionOut struct {
 	Elasticsearch *ElasticsearchOut `json:"elasticsearch,omitempty"`
 }
 type EventOut struct {
-	Actor       string    `json:"actor"`
-	EventDesc   string    `json:"event_desc"`
-	EventType   string    `json:"event_type"`
-	Id          string    `json:"id"`
-	ServiceName string    `json:"service_name"`
-	Time        time.Time `json:"time"`
+	Actor       string `json:"actor"`
+	EventDesc   string `json:"event_desc"`
+	EventType   string `json:"event_type"`
+	Id          string `json:"id"`
+	ServiceName string `json:"service_name"`
+	Time        string `json:"time"`
 }
 type GroupUserOut struct {
 	MemberType  string `json:"member_type"`

--- a/handler/service/service.go
+++ b/handler/service/service.go
@@ -678,17 +678,17 @@ type ListPublicServiceTypesOut struct {
 	Any *AnyOut `json:"ANY,omitempty"`
 }
 type LogOut struct {
-	Msg  string     `json:"msg"`
-	Time *time.Time `json:"time,omitempty"`
-	Unit string     `json:"unit,omitempty"`
+	Msg  string `json:"msg"`
+	Time string `json:"time,omitempty"`
+	Unit string `json:"unit,omitempty"`
 }
 type MaintenanceIn struct {
-	Dow  DowType    `json:"dow,omitempty"`
-	Time *time.Time `json:"time,omitempty"`
+	Dow  DowType `json:"dow,omitempty"`
+	Time string  `json:"time,omitempty"`
 }
 type MaintenanceOut struct {
 	Dow     string      `json:"dow"`
-	Time    time.Time   `json:"time"`
+	Time    string      `json:"time"`
 	Updates []UpdateOut `json:"updates"`
 }
 type MetadataOut struct {

--- a/handler/serviceuser/serviceuser.go
+++ b/handler/serviceuser/serviceuser.go
@@ -178,7 +178,7 @@ type IntegrationStatusOut struct {
 }
 type MaintenanceOut struct {
 	Dow     string      `json:"dow"`
-	Time    time.Time   `json:"time"`
+	Time    string      `json:"time"`
 	Updates []UpdateOut `json:"updates"`
 }
 type MetadataOut struct {


### PR DESCRIPTION
Fixes unmarshalling time fields that weren't actually timestamps.

NOTE! The only field that actually had this issue in the previous code were the `MaintenanceIn` and `MaintenanceOut` objects. Implementing an allowlist project events and logs would be better. Now they are returned as strings.