### PR TITLE
refactor: add out enum types

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -74,5 +74,5 @@ func TestServiceCreate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, out)
 	assert.Equal(t, "wow", out.Plan)
-	assert.Equal(t, "RUNNING", out.State)
+	assert.Equal(t, service.ServiceStateTypeRunning, out.State)
 }

--- a/handler/account/account.go
+++ b/handler/account/account.go
@@ -260,6 +260,19 @@ func (h *AccountHandler) AccountUsersSearch(ctx context.Context, accountId strin
 	return out.Users, nil
 }
 
+type AccessSourceType string
+
+const (
+	AccessSourceTypeDescendantMembership   AccessSourceType = "descendant_membership"
+	AccessSourceTypeOrganizationMembership AccessSourceType = "organization_membership"
+	AccessSourceTypeProjectMembership      AccessSourceType = "project_membership"
+	AccessSourceTypeTeamMembership         AccessSourceType = "team_membership"
+)
+
+func AccessSourceTypeChoices() []string {
+	return []string{"descendant_membership", "organization_membership", "project_membership", "team_membership"}
+}
+
 type AccountAttachPaymentMethodIn struct {
 	PaymentMethodId string `json:"payment_method_id"`
 }
@@ -276,26 +289,26 @@ type AccountAttachPaymentMethodOut struct {
 	Projects       []string `json:"projects"`
 }
 type AccountBillingGroupOut struct {
-	AccountId             string            `json:"account_id"`
-	AccountName           string            `json:"account_name"`
-	AddressLines          []string          `json:"address_lines"`
-	BillingAddress        string            `json:"billing_address,omitempty"`
-	BillingCurrency       string            `json:"billing_currency"`
-	BillingEmails         []BillingEmailOut `json:"billing_emails"`
-	BillingExtraText      string            `json:"billing_extra_text"`
-	BillingGroupId        string            `json:"billing_group_id"`
-	BillingGroupName      string            `json:"billing_group_name"`
-	CardInfo              CardInfoOut       `json:"card_info"`
-	City                  string            `json:"city"`
-	Company               string            `json:"company"`
-	Country               string            `json:"country"`
-	CountryCode           string            `json:"country_code"`
-	EstimatedBalanceLocal string            `json:"estimated_balance_local"`
-	EstimatedBalanceUsd   string            `json:"estimated_balance_usd"`
-	PaymentMethod         string            `json:"payment_method"`
-	State                 string            `json:"state"`
-	VatId                 string            `json:"vat_id"`
-	ZipCode               string            `json:"zip_code"`
+	AccountId             string              `json:"account_id"`
+	AccountName           string              `json:"account_name"`
+	AddressLines          []string            `json:"address_lines"`
+	BillingAddress        string              `json:"billing_address,omitempty"`
+	BillingCurrency       BillingCurrencyType `json:"billing_currency"`
+	BillingEmails         []BillingEmailOut   `json:"billing_emails"`
+	BillingExtraText      string              `json:"billing_extra_text"`
+	BillingGroupId        string              `json:"billing_group_id"`
+	BillingGroupName      string              `json:"billing_group_name"`
+	CardInfo              CardInfoOut         `json:"card_info"`
+	City                  string              `json:"city"`
+	Company               string              `json:"company"`
+	Country               string              `json:"country"`
+	CountryCode           string              `json:"country_code"`
+	EstimatedBalanceLocal string              `json:"estimated_balance_local"`
+	EstimatedBalanceUsd   string              `json:"estimated_balance_usd"`
+	PaymentMethod         PaymentMethodType   `json:"payment_method"`
+	State                 string              `json:"state"`
+	VatId                 string              `json:"vat_id"`
+	ZipCode               string              `json:"zip_code"`
 }
 type AccountCreateIn struct {
 	AccountName           string `json:"account_name"`
@@ -303,71 +316,71 @@ type AccountCreateIn struct {
 	PrimaryBillingGroupId string `json:"primary_billing_group_id,omitempty"`
 }
 type AccountCreateOut struct {
-	AccessSource          string         `json:"access_source,omitempty"`
-	AccountId             string         `json:"account_id"`
-	AccountName           string         `json:"account_name"`
-	AccountOwnerTeamId    string         `json:"account_owner_team_id"`
-	CreateTime            time.Time      `json:"create_time"`
-	Features              map[string]any `json:"features,omitempty"`
-	IsAccountMember       *bool          `json:"is_account_member,omitempty"`
-	IsAccountOwner        bool           `json:"is_account_owner"`
-	OrganizationId        string         `json:"organization_id"`
-	ParentAccountId       string         `json:"parent_account_id,omitempty"`
-	PrimaryBillingGroupId string         `json:"primary_billing_group_id"`
-	RootAccountId         string         `json:"root_account_id"`
-	TenantId              string         `json:"tenant_id,omitempty"`
-	UpdateTime            time.Time      `json:"update_time"`
+	AccessSource          AccessSourceType `json:"access_source,omitempty"`
+	AccountId             string           `json:"account_id"`
+	AccountName           string           `json:"account_name"`
+	AccountOwnerTeamId    string           `json:"account_owner_team_id"`
+	CreateTime            time.Time        `json:"create_time"`
+	Features              map[string]any   `json:"features,omitempty"`
+	IsAccountMember       *bool            `json:"is_account_member,omitempty"`
+	IsAccountOwner        bool             `json:"is_account_owner"`
+	OrganizationId        string           `json:"organization_id"`
+	ParentAccountId       string           `json:"parent_account_id,omitempty"`
+	PrimaryBillingGroupId string           `json:"primary_billing_group_id"`
+	RootAccountId         string           `json:"root_account_id"`
+	TenantId              string           `json:"tenant_id,omitempty"`
+	UpdateTime            time.Time        `json:"update_time"`
 }
 type AccountGetOut struct {
-	AccessSource          string         `json:"access_source,omitempty"`
-	AccountId             string         `json:"account_id"`
-	AccountName           string         `json:"account_name"`
-	AccountOwnerTeamId    string         `json:"account_owner_team_id"`
-	CreateTime            time.Time      `json:"create_time"`
-	Features              map[string]any `json:"features,omitempty"`
-	IsAccountMember       *bool          `json:"is_account_member,omitempty"`
-	IsAccountOwner        bool           `json:"is_account_owner"`
-	OrganizationId        string         `json:"organization_id"`
-	ParentAccountId       string         `json:"parent_account_id,omitempty"`
-	PrimaryBillingGroupId string         `json:"primary_billing_group_id"`
-	RootAccountId         string         `json:"root_account_id"`
-	TenantId              string         `json:"tenant_id,omitempty"`
-	UpdateTime            time.Time      `json:"update_time"`
+	AccessSource          AccessSourceType `json:"access_source,omitempty"`
+	AccountId             string           `json:"account_id"`
+	AccountName           string           `json:"account_name"`
+	AccountOwnerTeamId    string           `json:"account_owner_team_id"`
+	CreateTime            time.Time        `json:"create_time"`
+	Features              map[string]any   `json:"features,omitempty"`
+	IsAccountMember       *bool            `json:"is_account_member,omitempty"`
+	IsAccountOwner        bool             `json:"is_account_owner"`
+	OrganizationId        string           `json:"organization_id"`
+	ParentAccountId       string           `json:"parent_account_id,omitempty"`
+	PrimaryBillingGroupId string           `json:"primary_billing_group_id"`
+	RootAccountId         string           `json:"root_account_id"`
+	TenantId              string           `json:"tenant_id,omitempty"`
+	UpdateTime            time.Time        `json:"update_time"`
 }
 type AccountMoveIn struct {
 	ParentAccountId string `json:"parent_account_id"`
 }
 type AccountMoveOut struct {
-	AccessSource          string         `json:"access_source,omitempty"`
-	AccountId             string         `json:"account_id"`
-	AccountName           string         `json:"account_name"`
-	AccountOwnerTeamId    string         `json:"account_owner_team_id"`
-	CreateTime            time.Time      `json:"create_time"`
-	Features              map[string]any `json:"features,omitempty"`
-	IsAccountMember       *bool          `json:"is_account_member,omitempty"`
-	IsAccountOwner        bool           `json:"is_account_owner"`
-	OrganizationId        string         `json:"organization_id"`
-	ParentAccountId       string         `json:"parent_account_id,omitempty"`
-	PrimaryBillingGroupId string         `json:"primary_billing_group_id"`
-	RootAccountId         string         `json:"root_account_id"`
-	TenantId              string         `json:"tenant_id,omitempty"`
-	UpdateTime            time.Time      `json:"update_time"`
+	AccessSource          AccessSourceType `json:"access_source,omitempty"`
+	AccountId             string           `json:"account_id"`
+	AccountName           string           `json:"account_name"`
+	AccountOwnerTeamId    string           `json:"account_owner_team_id"`
+	CreateTime            time.Time        `json:"create_time"`
+	Features              map[string]any   `json:"features,omitempty"`
+	IsAccountMember       *bool            `json:"is_account_member,omitempty"`
+	IsAccountOwner        bool             `json:"is_account_owner"`
+	OrganizationId        string           `json:"organization_id"`
+	ParentAccountId       string           `json:"parent_account_id,omitempty"`
+	PrimaryBillingGroupId string           `json:"primary_billing_group_id"`
+	RootAccountId         string           `json:"root_account_id"`
+	TenantId              string           `json:"tenant_id,omitempty"`
+	UpdateTime            time.Time        `json:"update_time"`
 }
 type AccountOut struct {
-	AccessSource          string         `json:"access_source,omitempty"`
-	AccountId             string         `json:"account_id"`
-	AccountName           string         `json:"account_name"`
-	AccountOwnerTeamId    string         `json:"account_owner_team_id"`
-	CreateTime            time.Time      `json:"create_time"`
-	Features              map[string]any `json:"features,omitempty"`
-	IsAccountMember       *bool          `json:"is_account_member,omitempty"`
-	IsAccountOwner        bool           `json:"is_account_owner"`
-	OrganizationId        string         `json:"organization_id"`
-	ParentAccountId       string         `json:"parent_account_id,omitempty"`
-	PrimaryBillingGroupId string         `json:"primary_billing_group_id"`
-	RootAccountId         string         `json:"root_account_id"`
-	TenantId              string         `json:"tenant_id,omitempty"`
-	UpdateTime            time.Time      `json:"update_time"`
+	AccessSource          AccessSourceType `json:"access_source,omitempty"`
+	AccountId             string           `json:"account_id"`
+	AccountName           string           `json:"account_name"`
+	AccountOwnerTeamId    string           `json:"account_owner_team_id"`
+	CreateTime            time.Time        `json:"create_time"`
+	Features              map[string]any   `json:"features,omitempty"`
+	IsAccountMember       *bool            `json:"is_account_member,omitempty"`
+	IsAccountOwner        bool             `json:"is_account_owner"`
+	OrganizationId        string           `json:"organization_id"`
+	ParentAccountId       string           `json:"parent_account_id,omitempty"`
+	PrimaryBillingGroupId string           `json:"primary_billing_group_id"`
+	RootAccountId         string           `json:"root_account_id"`
+	TenantId              string           `json:"tenant_id,omitempty"`
+	UpdateTime            time.Time        `json:"update_time"`
 }
 type AccountProjectsListOut struct {
 	Projects          []ProjectOut `json:"projects"`
@@ -378,26 +391,47 @@ type AccountUpdateIn struct {
 	PrimaryBillingGroupId string `json:"primary_billing_group_id,omitempty"`
 }
 type AccountUpdateOut struct {
-	AccessSource          string         `json:"access_source,omitempty"`
-	AccountId             string         `json:"account_id"`
-	AccountName           string         `json:"account_name"`
-	AccountOwnerTeamId    string         `json:"account_owner_team_id"`
-	CreateTime            time.Time      `json:"create_time"`
-	Features              map[string]any `json:"features,omitempty"`
-	IsAccountMember       *bool          `json:"is_account_member,omitempty"`
-	IsAccountOwner        bool           `json:"is_account_owner"`
-	OrganizationId        string         `json:"organization_id"`
-	ParentAccountId       string         `json:"parent_account_id,omitempty"`
-	PrimaryBillingGroupId string         `json:"primary_billing_group_id"`
-	RootAccountId         string         `json:"root_account_id"`
-	TenantId              string         `json:"tenant_id,omitempty"`
-	UpdateTime            time.Time      `json:"update_time"`
+	AccessSource          AccessSourceType `json:"access_source,omitempty"`
+	AccountId             string           `json:"account_id"`
+	AccountName           string           `json:"account_name"`
+	AccountOwnerTeamId    string           `json:"account_owner_team_id"`
+	CreateTime            time.Time        `json:"create_time"`
+	Features              map[string]any   `json:"features,omitempty"`
+	IsAccountMember       *bool            `json:"is_account_member,omitempty"`
+	IsAccountOwner        bool             `json:"is_account_owner"`
+	OrganizationId        string           `json:"organization_id"`
+	ParentAccountId       string           `json:"parent_account_id,omitempty"`
+	PrimaryBillingGroupId string           `json:"primary_billing_group_id"`
+	RootAccountId         string           `json:"root_account_id"`
+	TenantId              string           `json:"tenant_id,omitempty"`
+	UpdateTime            time.Time        `json:"update_time"`
 }
 type AccountUsersSearchIn struct {
 	Limit   *int        `json:"limit,omitempty"`
 	OrderBy OrderByType `json:"order_by,omitempty"`
 	Query   string      `json:"query,omitempty"`
 }
+type BillingCurrencyType string
+
+const (
+	BillingCurrencyTypeAud BillingCurrencyType = "AUD"
+	BillingCurrencyTypeCad BillingCurrencyType = "CAD"
+	BillingCurrencyTypeChf BillingCurrencyType = "CHF"
+	BillingCurrencyTypeDkk BillingCurrencyType = "DKK"
+	BillingCurrencyTypeEur BillingCurrencyType = "EUR"
+	BillingCurrencyTypeGbp BillingCurrencyType = "GBP"
+	BillingCurrencyTypeJpy BillingCurrencyType = "JPY"
+	BillingCurrencyTypeNok BillingCurrencyType = "NOK"
+	BillingCurrencyTypeNzd BillingCurrencyType = "NZD"
+	BillingCurrencyTypeSek BillingCurrencyType = "SEK"
+	BillingCurrencyTypeSgd BillingCurrencyType = "SGD"
+	BillingCurrencyTypeUsd BillingCurrencyType = "USD"
+)
+
+func BillingCurrencyTypeChoices() []string {
+	return []string{"AUD", "CAD", "CHF", "DKK", "EUR", "GBP", "JPY", "NOK", "NZD", "SEK", "SGD", "USD"}
+}
+
 type BillingEmailOut struct {
 	Email string `json:"email"`
 }
@@ -439,6 +473,19 @@ type EventOut struct {
 	LogEntryId        int       `json:"log_entry_id"`
 	TeamId            string    `json:"team_id"`
 }
+type MemberType string
+
+const (
+	MemberTypeAdmin     MemberType = "admin"
+	MemberTypeDeveloper MemberType = "developer"
+	MemberTypeOperator  MemberType = "operator"
+	MemberTypeReadOnly  MemberType = "read_only"
+)
+
+func MemberTypeChoices() []string {
+	return []string{"admin", "developer", "operator", "read_only"}
+}
+
 type OrderByType string
 
 const (
@@ -454,13 +501,28 @@ func OrderByTypeChoices() []string {
 	return []string{"user_email:asc", "user_email:desc", "user_id:asc", "user_id:desc", "real_name:asc", "real_name:desc"}
 }
 
+type PaymentMethodType string
+
+const (
+	PaymentMethodTypeAccrual           PaymentMethodType = "accrual"
+	PaymentMethodTypeCard              PaymentMethodType = "card"
+	PaymentMethodTypeDisabled          PaymentMethodType = "disabled"
+	PaymentMethodTypeEmail             PaymentMethodType = "email"
+	PaymentMethodTypeNoPaymentExpected PaymentMethodType = "no_payment_expected"
+	PaymentMethodTypePartner           PaymentMethodType = "partner"
+)
+
+func PaymentMethodTypeChoices() []string {
+	return []string{"accrual", "card", "disabled", "email", "no_payment_expected", "partner"}
+}
+
 type ProjectOut struct {
 	AccountId             string                 `json:"account_id"`
 	AccountName           string                 `json:"account_name,omitempty"`
 	AddressLines          []string               `json:"address_lines,omitempty"`
 	AvailableCredits      string                 `json:"available_credits,omitempty"`
 	BillingAddress        string                 `json:"billing_address"`
-	BillingCurrency       string                 `json:"billing_currency,omitempty"`
+	BillingCurrency       BillingCurrencyType    `json:"billing_currency,omitempty"`
 	BillingEmails         []BillingEmailOut      `json:"billing_emails"`
 	BillingExtraText      string                 `json:"billing_extra_text,omitempty"`
 	BillingGroupId        string                 `json:"billing_group_id"`
@@ -495,15 +557,15 @@ type UserOut struct {
 	UserId    string `json:"user_id"`
 }
 type UserProjectOut struct {
-	AccessType  string    `json:"access_type,omitempty"`
-	AccountId   string    `json:"account_id"`
-	CreateTime  time.Time `json:"create_time"`
-	MemberType  string    `json:"member_type"`
-	ProjectName string    `json:"project_name"`
-	RealName    string    `json:"real_name"`
-	TeamId      string    `json:"team_id"`
-	TeamName    string    `json:"team_name"`
-	UserEmail   string    `json:"user_email"`
+	AccessType  string     `json:"access_type,omitempty"`
+	AccountId   string     `json:"account_id"`
+	CreateTime  time.Time  `json:"create_time"`
+	MemberType  MemberType `json:"member_type"`
+	ProjectName string     `json:"project_name"`
+	RealName    string     `json:"real_name"`
+	TeamId      string     `json:"team_id"`
+	TeamName    string     `json:"team_name"`
+	UserEmail   string     `json:"user_email"`
 }
 type accountAttachPaymentMethodOut struct {
 	Card AccountAttachPaymentMethodOut `json:"card"`

--- a/handler/accountauthentication/accountauthentication.go
+++ b/handler/accountauthentication/accountauthentication.go
@@ -125,76 +125,81 @@ type AccountAuthenticationMethodCreateIn struct {
 	SamlRequestedAuthnContextEnabled *bool                      `json:"saml_requested_authn_context_enabled,omitempty"`
 	SamlSignatureAlgorithm           SamlSignatureAlgorithmType `json:"saml_signature_algorithm,omitempty"`
 	SamlVariant                      SamlVariantType            `json:"saml_variant,omitempty"`
+	ScimEnabled                      *bool                      `json:"scim_enabled,omitempty"`
 }
 type AccountAuthenticationMethodCreateOut struct {
-	AccountId                        string               `json:"account_id"`
-	AuthTokenExtendWhenUsed          *bool                `json:"auth_token_extend_when_used,omitempty"`
-	AuthTokenMaxAgeSeconds           *int                 `json:"auth_token_max_age_seconds,omitempty"`
-	AuthenticationMethodEnabled      bool                 `json:"authentication_method_enabled"`
-	AuthenticationMethodId           string               `json:"authentication_method_id"`
-	AuthenticationMethodName         string               `json:"authentication_method_name,omitempty"`
-	AuthenticationMethodType         string               `json:"authentication_method_type"`
-	AutoJoinTeamId                   string               `json:"auto_join_team_id"`
-	AutoJoinUserGroupId              string               `json:"auto_join_user_group_id"`
-	CreateTime                       time.Time            `json:"create_time"`
-	DeleteTime                       time.Time            `json:"delete_time"`
-	OrganizationId                   string               `json:"organization_id,omitempty"`
-	SamlAcsUrl                       string               `json:"saml_acs_url,omitempty"`
-	SamlAssertionSignedEnabled       *bool                `json:"saml_assertion_signed_enabled,omitempty"`
-	SamlAuthnRequestsSignedEnabled   *bool                `json:"saml_authn_requests_signed_enabled,omitempty"`
-	SamlCert                         string               `json:"saml_cert,omitempty"`
-	SamlCertificate                  string               `json:"saml_certificate,omitempty"`
-	SamlCertificateIssuer            string               `json:"saml_certificate_issuer,omitempty"`
-	SamlCertificateNotValidAfter     string               `json:"saml_certificate_not_valid_after,omitempty"`
-	SamlCertificateNotValidBefore    string               `json:"saml_certificate_not_valid_before,omitempty"`
-	SamlCertificateSubject           string               `json:"saml_certificate_subject,omitempty"`
-	SamlDigestAlgorithm              string               `json:"saml_digest_algorithm,omitempty"`
-	SamlEntityId                     string               `json:"saml_entity_id,omitempty"`
-	SamlFieldMapping                 *SamlFieldMappingOut `json:"saml_field_mapping,omitempty"`
-	SamlIdpLoginAllowed              *bool                `json:"saml_idp_login_allowed,omitempty"`
-	SamlIdpUrl                       string               `json:"saml_idp_url,omitempty"`
-	SamlMetadataUrl                  string               `json:"saml_metadata_url,omitempty"`
-	SamlRequestedAuthnContextEnabled *bool                `json:"saml_requested_authn_context_enabled,omitempty"`
-	SamlSignatureAlgorithm           string               `json:"saml_signature_algorithm,omitempty"`
-	SamlSpCertificate                string               `json:"saml_sp_certificate,omitempty"`
-	SamlVariant                      string               `json:"saml_variant,omitempty"`
-	State                            string               `json:"state"`
-	UpdateTime                       time.Time            `json:"update_time"`
+	AccountId                        string                        `json:"account_id"`
+	AuthTokenExtendWhenUsed          *bool                         `json:"auth_token_extend_when_used,omitempty"`
+	AuthTokenMaxAgeSeconds           *int                          `json:"auth_token_max_age_seconds,omitempty"`
+	AuthenticationMethodEnabled      bool                          `json:"authentication_method_enabled"`
+	AuthenticationMethodId           string                        `json:"authentication_method_id"`
+	AuthenticationMethodName         string                        `json:"authentication_method_name,omitempty"`
+	AuthenticationMethodType         AuthenticationMethodType      `json:"authentication_method_type"`
+	AutoJoinTeamId                   string                        `json:"auto_join_team_id"`
+	AutoJoinUserGroupId              string                        `json:"auto_join_user_group_id"`
+	CreateTime                       time.Time                     `json:"create_time"`
+	DeleteTime                       time.Time                     `json:"delete_time"`
+	OrganizationId                   string                        `json:"organization_id,omitempty"`
+	SamlAcsUrl                       string                        `json:"saml_acs_url,omitempty"`
+	SamlAssertionSignedEnabled       *bool                         `json:"saml_assertion_signed_enabled,omitempty"`
+	SamlAuthnRequestsSignedEnabled   *bool                         `json:"saml_authn_requests_signed_enabled,omitempty"`
+	SamlCert                         SamlCertType                  `json:"saml_cert,omitempty"`
+	SamlCertificate                  string                        `json:"saml_certificate,omitempty"`
+	SamlCertificateIssuer            string                        `json:"saml_certificate_issuer,omitempty"`
+	SamlCertificateNotValidAfter     string                        `json:"saml_certificate_not_valid_after,omitempty"`
+	SamlCertificateNotValidBefore    string                        `json:"saml_certificate_not_valid_before,omitempty"`
+	SamlCertificateSubject           string                        `json:"saml_certificate_subject,omitempty"`
+	SamlDigestAlgorithm              SamlDigestAlgorithmType       `json:"saml_digest_algorithm,omitempty"`
+	SamlEntityId                     string                        `json:"saml_entity_id,omitempty"`
+	SamlFieldMapping                 *SamlFieldMappingOut          `json:"saml_field_mapping,omitempty"`
+	SamlIdpLoginAllowed              *bool                         `json:"saml_idp_login_allowed,omitempty"`
+	SamlIdpUrl                       string                        `json:"saml_idp_url,omitempty"`
+	SamlMetadataUrl                  string                        `json:"saml_metadata_url,omitempty"`
+	SamlRequestedAuthnContextEnabled *bool                         `json:"saml_requested_authn_context_enabled,omitempty"`
+	SamlSignatureAlgorithm           SamlSignatureAlgorithmType    `json:"saml_signature_algorithm,omitempty"`
+	SamlSpCertificate                string                        `json:"saml_sp_certificate,omitempty"`
+	SamlVariant                      SamlVariantType               `json:"saml_variant,omitempty"`
+	ScimEnabled                      *bool                         `json:"scim_enabled,omitempty"`
+	ScimUrl                          string                        `json:"scim_url,omitempty"`
+	State                            AuthenticationMethodStateType `json:"state"`
+	UpdateTime                       time.Time                     `json:"update_time"`
 }
 type AccountAuthenticationMethodGetOut struct {
-	AccountId                        string               `json:"account_id"`
-	AuthTokenExtendWhenUsed          *bool                `json:"auth_token_extend_when_used,omitempty"`
-	AuthTokenMaxAgeSeconds           *int                 `json:"auth_token_max_age_seconds,omitempty"`
-	AuthenticationMethodEnabled      bool                 `json:"authentication_method_enabled"`
-	AuthenticationMethodId           string               `json:"authentication_method_id"`
-	AuthenticationMethodName         string               `json:"authentication_method_name,omitempty"`
-	AuthenticationMethodType         string               `json:"authentication_method_type"`
-	AutoJoinTeamId                   string               `json:"auto_join_team_id"`
-	AutoJoinUserGroupId              string               `json:"auto_join_user_group_id"`
-	CreateTime                       time.Time            `json:"create_time"`
-	DeleteTime                       time.Time            `json:"delete_time"`
-	OrganizationId                   string               `json:"organization_id,omitempty"`
-	SamlAcsUrl                       string               `json:"saml_acs_url,omitempty"`
-	SamlAssertionSignedEnabled       *bool                `json:"saml_assertion_signed_enabled,omitempty"`
-	SamlAuthnRequestsSignedEnabled   *bool                `json:"saml_authn_requests_signed_enabled,omitempty"`
-	SamlCert                         string               `json:"saml_cert,omitempty"`
-	SamlCertificate                  string               `json:"saml_certificate,omitempty"`
-	SamlCertificateIssuer            string               `json:"saml_certificate_issuer,omitempty"`
-	SamlCertificateNotValidAfter     string               `json:"saml_certificate_not_valid_after,omitempty"`
-	SamlCertificateNotValidBefore    string               `json:"saml_certificate_not_valid_before,omitempty"`
-	SamlCertificateSubject           string               `json:"saml_certificate_subject,omitempty"`
-	SamlDigestAlgorithm              string               `json:"saml_digest_algorithm,omitempty"`
-	SamlEntityId                     string               `json:"saml_entity_id,omitempty"`
-	SamlFieldMapping                 *SamlFieldMappingOut `json:"saml_field_mapping,omitempty"`
-	SamlIdpLoginAllowed              *bool                `json:"saml_idp_login_allowed,omitempty"`
-	SamlIdpUrl                       string               `json:"saml_idp_url,omitempty"`
-	SamlMetadataUrl                  string               `json:"saml_metadata_url,omitempty"`
-	SamlRequestedAuthnContextEnabled *bool                `json:"saml_requested_authn_context_enabled,omitempty"`
-	SamlSignatureAlgorithm           string               `json:"saml_signature_algorithm,omitempty"`
-	SamlSpCertificate                string               `json:"saml_sp_certificate,omitempty"`
-	SamlVariant                      string               `json:"saml_variant,omitempty"`
-	State                            string               `json:"state"`
-	UpdateTime                       time.Time            `json:"update_time"`
+	AccountId                        string                        `json:"account_id"`
+	AuthTokenExtendWhenUsed          *bool                         `json:"auth_token_extend_when_used,omitempty"`
+	AuthTokenMaxAgeSeconds           *int                          `json:"auth_token_max_age_seconds,omitempty"`
+	AuthenticationMethodEnabled      bool                          `json:"authentication_method_enabled"`
+	AuthenticationMethodId           string                        `json:"authentication_method_id"`
+	AuthenticationMethodName         string                        `json:"authentication_method_name,omitempty"`
+	AuthenticationMethodType         AuthenticationMethodType      `json:"authentication_method_type"`
+	AutoJoinTeamId                   string                        `json:"auto_join_team_id"`
+	AutoJoinUserGroupId              string                        `json:"auto_join_user_group_id"`
+	CreateTime                       time.Time                     `json:"create_time"`
+	DeleteTime                       time.Time                     `json:"delete_time"`
+	OrganizationId                   string                        `json:"organization_id,omitempty"`
+	SamlAcsUrl                       string                        `json:"saml_acs_url,omitempty"`
+	SamlAssertionSignedEnabled       *bool                         `json:"saml_assertion_signed_enabled,omitempty"`
+	SamlAuthnRequestsSignedEnabled   *bool                         `json:"saml_authn_requests_signed_enabled,omitempty"`
+	SamlCert                         SamlCertType                  `json:"saml_cert,omitempty"`
+	SamlCertificate                  string                        `json:"saml_certificate,omitempty"`
+	SamlCertificateIssuer            string                        `json:"saml_certificate_issuer,omitempty"`
+	SamlCertificateNotValidAfter     string                        `json:"saml_certificate_not_valid_after,omitempty"`
+	SamlCertificateNotValidBefore    string                        `json:"saml_certificate_not_valid_before,omitempty"`
+	SamlCertificateSubject           string                        `json:"saml_certificate_subject,omitempty"`
+	SamlDigestAlgorithm              SamlDigestAlgorithmType       `json:"saml_digest_algorithm,omitempty"`
+	SamlEntityId                     string                        `json:"saml_entity_id,omitempty"`
+	SamlFieldMapping                 *SamlFieldMappingOut          `json:"saml_field_mapping,omitempty"`
+	SamlIdpLoginAllowed              *bool                         `json:"saml_idp_login_allowed,omitempty"`
+	SamlIdpUrl                       string                        `json:"saml_idp_url,omitempty"`
+	SamlMetadataUrl                  string                        `json:"saml_metadata_url,omitempty"`
+	SamlRequestedAuthnContextEnabled *bool                         `json:"saml_requested_authn_context_enabled,omitempty"`
+	SamlSignatureAlgorithm           SamlSignatureAlgorithmType    `json:"saml_signature_algorithm,omitempty"`
+	SamlSpCertificate                string                        `json:"saml_sp_certificate,omitempty"`
+	SamlVariant                      SamlVariantType               `json:"saml_variant,omitempty"`
+	ScimEnabled                      *bool                         `json:"scim_enabled,omitempty"`
+	ScimUrl                          string                        `json:"scim_url,omitempty"`
+	State                            AuthenticationMethodStateType `json:"state"`
+	UpdateTime                       time.Time                     `json:"update_time"`
 }
 type AccountAuthenticationMethodUpdateIn struct {
 	AuthTokenExtendWhenUsed          *bool                      `json:"auth_token_extend_when_used,omitempty"`
@@ -214,77 +219,94 @@ type AccountAuthenticationMethodUpdateIn struct {
 	SamlRequestedAuthnContextEnabled *bool                      `json:"saml_requested_authn_context_enabled,omitempty"`
 	SamlSignatureAlgorithm           SamlSignatureAlgorithmType `json:"saml_signature_algorithm,omitempty"`
 	SamlVariant                      SamlVariantType            `json:"saml_variant,omitempty"`
+	ScimEnabled                      *bool                      `json:"scim_enabled,omitempty"`
 }
 type AccountAuthenticationMethodUpdateOut struct {
-	AccountId                        string               `json:"account_id"`
-	AuthTokenExtendWhenUsed          *bool                `json:"auth_token_extend_when_used,omitempty"`
-	AuthTokenMaxAgeSeconds           *int                 `json:"auth_token_max_age_seconds,omitempty"`
-	AuthenticationMethodEnabled      bool                 `json:"authentication_method_enabled"`
-	AuthenticationMethodId           string               `json:"authentication_method_id"`
-	AuthenticationMethodName         string               `json:"authentication_method_name,omitempty"`
-	AuthenticationMethodType         string               `json:"authentication_method_type"`
-	AutoJoinTeamId                   string               `json:"auto_join_team_id"`
-	AutoJoinUserGroupId              string               `json:"auto_join_user_group_id"`
-	CreateTime                       time.Time            `json:"create_time"`
-	DeleteTime                       time.Time            `json:"delete_time"`
-	OrganizationId                   string               `json:"organization_id,omitempty"`
-	SamlAcsUrl                       string               `json:"saml_acs_url,omitempty"`
-	SamlAssertionSignedEnabled       *bool                `json:"saml_assertion_signed_enabled,omitempty"`
-	SamlAuthnRequestsSignedEnabled   *bool                `json:"saml_authn_requests_signed_enabled,omitempty"`
-	SamlCert                         string               `json:"saml_cert,omitempty"`
-	SamlCertificate                  string               `json:"saml_certificate,omitempty"`
-	SamlCertificateIssuer            string               `json:"saml_certificate_issuer,omitempty"`
-	SamlCertificateNotValidAfter     string               `json:"saml_certificate_not_valid_after,omitempty"`
-	SamlCertificateNotValidBefore    string               `json:"saml_certificate_not_valid_before,omitempty"`
-	SamlCertificateSubject           string               `json:"saml_certificate_subject,omitempty"`
-	SamlDigestAlgorithm              string               `json:"saml_digest_algorithm,omitempty"`
-	SamlEntityId                     string               `json:"saml_entity_id,omitempty"`
-	SamlFieldMapping                 *SamlFieldMappingOut `json:"saml_field_mapping,omitempty"`
-	SamlIdpLoginAllowed              *bool                `json:"saml_idp_login_allowed,omitempty"`
-	SamlIdpUrl                       string               `json:"saml_idp_url,omitempty"`
-	SamlMetadataUrl                  string               `json:"saml_metadata_url,omitempty"`
-	SamlRequestedAuthnContextEnabled *bool                `json:"saml_requested_authn_context_enabled,omitempty"`
-	SamlSignatureAlgorithm           string               `json:"saml_signature_algorithm,omitempty"`
-	SamlSpCertificate                string               `json:"saml_sp_certificate,omitempty"`
-	SamlVariant                      string               `json:"saml_variant,omitempty"`
-	State                            string               `json:"state"`
-	UpdateTime                       time.Time            `json:"update_time"`
+	AccountId                        string                        `json:"account_id"`
+	AuthTokenExtendWhenUsed          *bool                         `json:"auth_token_extend_when_used,omitempty"`
+	AuthTokenMaxAgeSeconds           *int                          `json:"auth_token_max_age_seconds,omitempty"`
+	AuthenticationMethodEnabled      bool                          `json:"authentication_method_enabled"`
+	AuthenticationMethodId           string                        `json:"authentication_method_id"`
+	AuthenticationMethodName         string                        `json:"authentication_method_name,omitempty"`
+	AuthenticationMethodType         AuthenticationMethodType      `json:"authentication_method_type"`
+	AutoJoinTeamId                   string                        `json:"auto_join_team_id"`
+	AutoJoinUserGroupId              string                        `json:"auto_join_user_group_id"`
+	CreateTime                       time.Time                     `json:"create_time"`
+	DeleteTime                       time.Time                     `json:"delete_time"`
+	OrganizationId                   string                        `json:"organization_id,omitempty"`
+	SamlAcsUrl                       string                        `json:"saml_acs_url,omitempty"`
+	SamlAssertionSignedEnabled       *bool                         `json:"saml_assertion_signed_enabled,omitempty"`
+	SamlAuthnRequestsSignedEnabled   *bool                         `json:"saml_authn_requests_signed_enabled,omitempty"`
+	SamlCert                         SamlCertType                  `json:"saml_cert,omitempty"`
+	SamlCertificate                  string                        `json:"saml_certificate,omitempty"`
+	SamlCertificateIssuer            string                        `json:"saml_certificate_issuer,omitempty"`
+	SamlCertificateNotValidAfter     string                        `json:"saml_certificate_not_valid_after,omitempty"`
+	SamlCertificateNotValidBefore    string                        `json:"saml_certificate_not_valid_before,omitempty"`
+	SamlCertificateSubject           string                        `json:"saml_certificate_subject,omitempty"`
+	SamlDigestAlgorithm              SamlDigestAlgorithmType       `json:"saml_digest_algorithm,omitempty"`
+	SamlEntityId                     string                        `json:"saml_entity_id,omitempty"`
+	SamlFieldMapping                 *SamlFieldMappingOut          `json:"saml_field_mapping,omitempty"`
+	SamlIdpLoginAllowed              *bool                         `json:"saml_idp_login_allowed,omitempty"`
+	SamlIdpUrl                       string                        `json:"saml_idp_url,omitempty"`
+	SamlMetadataUrl                  string                        `json:"saml_metadata_url,omitempty"`
+	SamlRequestedAuthnContextEnabled *bool                         `json:"saml_requested_authn_context_enabled,omitempty"`
+	SamlSignatureAlgorithm           SamlSignatureAlgorithmType    `json:"saml_signature_algorithm,omitempty"`
+	SamlSpCertificate                string                        `json:"saml_sp_certificate,omitempty"`
+	SamlVariant                      SamlVariantType               `json:"saml_variant,omitempty"`
+	ScimEnabled                      *bool                         `json:"scim_enabled,omitempty"`
+	ScimUrl                          string                        `json:"scim_url,omitempty"`
+	State                            AuthenticationMethodStateType `json:"state"`
+	UpdateTime                       time.Time                     `json:"update_time"`
 }
 type AuthenticationMethodOut struct {
-	AccountId                        string               `json:"account_id"`
-	AuthTokenExtendWhenUsed          *bool                `json:"auth_token_extend_when_used,omitempty"`
-	AuthTokenMaxAgeSeconds           *int                 `json:"auth_token_max_age_seconds,omitempty"`
-	AuthenticationMethodEnabled      bool                 `json:"authentication_method_enabled"`
-	AuthenticationMethodId           string               `json:"authentication_method_id"`
-	AuthenticationMethodName         string               `json:"authentication_method_name,omitempty"`
-	AuthenticationMethodType         string               `json:"authentication_method_type"`
-	AutoJoinTeamId                   string               `json:"auto_join_team_id"`
-	AutoJoinUserGroupId              string               `json:"auto_join_user_group_id"`
-	CreateTime                       time.Time            `json:"create_time"`
-	DeleteTime                       time.Time            `json:"delete_time"`
-	OrganizationId                   string               `json:"organization_id,omitempty"`
-	SamlAcsUrl                       string               `json:"saml_acs_url,omitempty"`
-	SamlAssertionSignedEnabled       *bool                `json:"saml_assertion_signed_enabled,omitempty"`
-	SamlAuthnRequestsSignedEnabled   *bool                `json:"saml_authn_requests_signed_enabled,omitempty"`
-	SamlCert                         string               `json:"saml_cert,omitempty"`
-	SamlCertificate                  string               `json:"saml_certificate,omitempty"`
-	SamlCertificateIssuer            string               `json:"saml_certificate_issuer,omitempty"`
-	SamlCertificateNotValidAfter     string               `json:"saml_certificate_not_valid_after,omitempty"`
-	SamlCertificateNotValidBefore    string               `json:"saml_certificate_not_valid_before,omitempty"`
-	SamlCertificateSubject           string               `json:"saml_certificate_subject,omitempty"`
-	SamlDigestAlgorithm              string               `json:"saml_digest_algorithm,omitempty"`
-	SamlEntityId                     string               `json:"saml_entity_id,omitempty"`
-	SamlFieldMapping                 *SamlFieldMappingOut `json:"saml_field_mapping,omitempty"`
-	SamlIdpLoginAllowed              *bool                `json:"saml_idp_login_allowed,omitempty"`
-	SamlIdpUrl                       string               `json:"saml_idp_url,omitempty"`
-	SamlMetadataUrl                  string               `json:"saml_metadata_url,omitempty"`
-	SamlRequestedAuthnContextEnabled *bool                `json:"saml_requested_authn_context_enabled,omitempty"`
-	SamlSignatureAlgorithm           string               `json:"saml_signature_algorithm,omitempty"`
-	SamlSpCertificate                string               `json:"saml_sp_certificate,omitempty"`
-	SamlVariant                      string               `json:"saml_variant,omitempty"`
-	State                            string               `json:"state"`
-	UpdateTime                       time.Time            `json:"update_time"`
+	AccountId                        string                        `json:"account_id"`
+	AuthTokenExtendWhenUsed          *bool                         `json:"auth_token_extend_when_used,omitempty"`
+	AuthTokenMaxAgeSeconds           *int                          `json:"auth_token_max_age_seconds,omitempty"`
+	AuthenticationMethodEnabled      bool                          `json:"authentication_method_enabled"`
+	AuthenticationMethodId           string                        `json:"authentication_method_id"`
+	AuthenticationMethodName         string                        `json:"authentication_method_name,omitempty"`
+	AuthenticationMethodType         AuthenticationMethodType      `json:"authentication_method_type"`
+	AutoJoinTeamId                   string                        `json:"auto_join_team_id"`
+	AutoJoinUserGroupId              string                        `json:"auto_join_user_group_id"`
+	CreateTime                       time.Time                     `json:"create_time"`
+	DeleteTime                       time.Time                     `json:"delete_time"`
+	OrganizationId                   string                        `json:"organization_id,omitempty"`
+	SamlAcsUrl                       string                        `json:"saml_acs_url,omitempty"`
+	SamlAssertionSignedEnabled       *bool                         `json:"saml_assertion_signed_enabled,omitempty"`
+	SamlAuthnRequestsSignedEnabled   *bool                         `json:"saml_authn_requests_signed_enabled,omitempty"`
+	SamlCert                         SamlCertType                  `json:"saml_cert,omitempty"`
+	SamlCertificate                  string                        `json:"saml_certificate,omitempty"`
+	SamlCertificateIssuer            string                        `json:"saml_certificate_issuer,omitempty"`
+	SamlCertificateNotValidAfter     string                        `json:"saml_certificate_not_valid_after,omitempty"`
+	SamlCertificateNotValidBefore    string                        `json:"saml_certificate_not_valid_before,omitempty"`
+	SamlCertificateSubject           string                        `json:"saml_certificate_subject,omitempty"`
+	SamlDigestAlgorithm              SamlDigestAlgorithmType       `json:"saml_digest_algorithm,omitempty"`
+	SamlEntityId                     string                        `json:"saml_entity_id,omitempty"`
+	SamlFieldMapping                 *SamlFieldMappingOut          `json:"saml_field_mapping,omitempty"`
+	SamlIdpLoginAllowed              *bool                         `json:"saml_idp_login_allowed,omitempty"`
+	SamlIdpUrl                       string                        `json:"saml_idp_url,omitempty"`
+	SamlMetadataUrl                  string                        `json:"saml_metadata_url,omitempty"`
+	SamlRequestedAuthnContextEnabled *bool                         `json:"saml_requested_authn_context_enabled,omitempty"`
+	SamlSignatureAlgorithm           SamlSignatureAlgorithmType    `json:"saml_signature_algorithm,omitempty"`
+	SamlSpCertificate                string                        `json:"saml_sp_certificate,omitempty"`
+	SamlVariant                      SamlVariantType               `json:"saml_variant,omitempty"`
+	ScimEnabled                      *bool                         `json:"scim_enabled,omitempty"`
+	ScimUrl                          string                        `json:"scim_url,omitempty"`
+	State                            AuthenticationMethodStateType `json:"state"`
+	UpdateTime                       time.Time                     `json:"update_time"`
 }
+type AuthenticationMethodStateType string
+
+const (
+	AuthenticationMethodStateTypeActive               AuthenticationMethodStateType = "active"
+	AuthenticationMethodStateTypeDeleted              AuthenticationMethodStateType = "deleted"
+	AuthenticationMethodStateTypePendingConfiguration AuthenticationMethodStateType = "pending_configuration"
+)
+
+func AuthenticationMethodStateTypeChoices() []string {
+	return []string{"active", "deleted", "pending_configuration"}
+}
+
 type AuthenticationMethodType string
 
 const (
@@ -299,6 +321,16 @@ func AuthenticationMethodTypeChoices() []string {
 type LinkedDomainIn struct {
 	DomainId string `json:"domain_id"`
 }
+type SamlCertType string
+
+const (
+	SamlCertTypeAdfs SamlCertType = "adfs"
+)
+
+func SamlCertTypeChoices() []string {
+	return []string{"adfs"}
+}
+
 type SamlDigestAlgorithmType string
 
 const (

--- a/handler/billinggroup/billinggroup.go
+++ b/handler/billinggroup/billinggroup.go
@@ -278,26 +278,26 @@ type BillingGroupCreateIn struct {
 	ZipCode              string              `json:"zip_code,omitempty"`
 }
 type BillingGroupCreateOut struct {
-	AccountId             string            `json:"account_id"`
-	AccountName           string            `json:"account_name"`
-	AddressLines          []string          `json:"address_lines"`
-	BillingAddress        string            `json:"billing_address,omitempty"`
-	BillingCurrency       string            `json:"billing_currency"`
-	BillingEmails         []BillingEmailOut `json:"billing_emails"`
-	BillingExtraText      string            `json:"billing_extra_text"`
-	BillingGroupId        string            `json:"billing_group_id"`
-	BillingGroupName      string            `json:"billing_group_name"`
-	CardInfo              CardInfoOut       `json:"card_info"`
-	City                  string            `json:"city"`
-	Company               string            `json:"company"`
-	Country               string            `json:"country"`
-	CountryCode           string            `json:"country_code"`
-	EstimatedBalanceLocal string            `json:"estimated_balance_local"`
-	EstimatedBalanceUsd   string            `json:"estimated_balance_usd"`
-	PaymentMethod         string            `json:"payment_method"`
-	State                 string            `json:"state"`
-	VatId                 string            `json:"vat_id"`
-	ZipCode               string            `json:"zip_code"`
+	AccountId             string              `json:"account_id"`
+	AccountName           string              `json:"account_name"`
+	AddressLines          []string            `json:"address_lines"`
+	BillingAddress        string              `json:"billing_address,omitempty"`
+	BillingCurrency       BillingCurrencyType `json:"billing_currency"`
+	BillingEmails         []BillingEmailOut   `json:"billing_emails"`
+	BillingExtraText      string              `json:"billing_extra_text"`
+	BillingGroupId        string              `json:"billing_group_id"`
+	BillingGroupName      string              `json:"billing_group_name"`
+	CardInfo              CardInfoOut         `json:"card_info"`
+	City                  string              `json:"city"`
+	Company               string              `json:"company"`
+	Country               string              `json:"country"`
+	CountryCode           string              `json:"country_code"`
+	EstimatedBalanceLocal string              `json:"estimated_balance_local"`
+	EstimatedBalanceUsd   string              `json:"estimated_balance_usd"`
+	PaymentMethod         PaymentMethodType   `json:"payment_method"`
+	State                 string              `json:"state"`
+	VatId                 string              `json:"vat_id"`
+	ZipCode               string              `json:"zip_code"`
 }
 type BillingGroupCreditsClaimIn struct {
 	Code string `json:"code"`
@@ -307,56 +307,67 @@ type BillingGroupCreditsClaimOut struct {
 	ExpireTime     *time.Time `json:"expire_time,omitempty"`
 	RemainingValue string     `json:"remaining_value,omitempty"`
 	StartTime      *time.Time `json:"start_time,omitempty"`
-	Type           string     `json:"type,omitempty"`
+	Type           CreditType `json:"type,omitempty"`
 	Value          string     `json:"value,omitempty"`
 }
 type BillingGroupGetOut struct {
-	AccountId             string            `json:"account_id"`
-	AccountName           string            `json:"account_name"`
-	AddressLines          []string          `json:"address_lines"`
-	BillingAddress        string            `json:"billing_address,omitempty"`
-	BillingCurrency       string            `json:"billing_currency"`
-	BillingEmails         []BillingEmailOut `json:"billing_emails"`
-	BillingExtraText      string            `json:"billing_extra_text"`
-	BillingGroupId        string            `json:"billing_group_id"`
-	BillingGroupName      string            `json:"billing_group_name"`
-	CardInfo              CardInfoOut       `json:"card_info"`
-	City                  string            `json:"city"`
-	Company               string            `json:"company"`
-	Country               string            `json:"country"`
-	CountryCode           string            `json:"country_code"`
-	EstimatedBalanceLocal string            `json:"estimated_balance_local"`
-	EstimatedBalanceUsd   string            `json:"estimated_balance_usd"`
-	PaymentMethod         string            `json:"payment_method"`
-	State                 string            `json:"state"`
-	VatId                 string            `json:"vat_id"`
-	ZipCode               string            `json:"zip_code"`
+	AccountId             string              `json:"account_id"`
+	AccountName           string              `json:"account_name"`
+	AddressLines          []string            `json:"address_lines"`
+	BillingAddress        string              `json:"billing_address,omitempty"`
+	BillingCurrency       BillingCurrencyType `json:"billing_currency"`
+	BillingEmails         []BillingEmailOut   `json:"billing_emails"`
+	BillingExtraText      string              `json:"billing_extra_text"`
+	BillingGroupId        string              `json:"billing_group_id"`
+	BillingGroupName      string              `json:"billing_group_name"`
+	CardInfo              CardInfoOut         `json:"card_info"`
+	City                  string              `json:"city"`
+	Company               string              `json:"company"`
+	Country               string              `json:"country"`
+	CountryCode           string              `json:"country_code"`
+	EstimatedBalanceLocal string              `json:"estimated_balance_local"`
+	EstimatedBalanceUsd   string              `json:"estimated_balance_usd"`
+	PaymentMethod         PaymentMethodType   `json:"payment_method"`
+	State                 string              `json:"state"`
+	VatId                 string              `json:"vat_id"`
+	ZipCode               string              `json:"zip_code"`
 }
 type BillingGroupOut struct {
-	AccountId             string            `json:"account_id"`
-	AccountName           string            `json:"account_name"`
-	AddressLines          []string          `json:"address_lines"`
-	BillingAddress        string            `json:"billing_address,omitempty"`
-	BillingCurrency       string            `json:"billing_currency"`
-	BillingEmails         []BillingEmailOut `json:"billing_emails"`
-	BillingExtraText      string            `json:"billing_extra_text"`
-	BillingGroupId        string            `json:"billing_group_id"`
-	BillingGroupName      string            `json:"billing_group_name"`
-	CardInfo              CardInfoOut       `json:"card_info"`
-	City                  string            `json:"city"`
-	Company               string            `json:"company"`
-	Country               string            `json:"country"`
-	CountryCode           string            `json:"country_code"`
-	EstimatedBalanceLocal string            `json:"estimated_balance_local"`
-	EstimatedBalanceUsd   string            `json:"estimated_balance_usd"`
-	PaymentMethod         string            `json:"payment_method"`
-	State                 string            `json:"state"`
-	VatId                 string            `json:"vat_id"`
-	ZipCode               string            `json:"zip_code"`
+	AccountId             string              `json:"account_id"`
+	AccountName           string              `json:"account_name"`
+	AddressLines          []string            `json:"address_lines"`
+	BillingAddress        string              `json:"billing_address,omitempty"`
+	BillingCurrency       BillingCurrencyType `json:"billing_currency"`
+	BillingEmails         []BillingEmailOut   `json:"billing_emails"`
+	BillingExtraText      string              `json:"billing_extra_text"`
+	BillingGroupId        string              `json:"billing_group_id"`
+	BillingGroupName      string              `json:"billing_group_name"`
+	CardInfo              CardInfoOut         `json:"card_info"`
+	City                  string              `json:"city"`
+	Company               string              `json:"company"`
+	Country               string              `json:"country"`
+	CountryCode           string              `json:"country_code"`
+	EstimatedBalanceLocal string              `json:"estimated_balance_local"`
+	EstimatedBalanceUsd   string              `json:"estimated_balance_usd"`
+	PaymentMethod         PaymentMethodType   `json:"payment_method"`
+	State                 string              `json:"state"`
+	VatId                 string              `json:"vat_id"`
+	ZipCode               string              `json:"zip_code"`
 }
 type BillingGroupProjectsAssignIn struct {
 	ProjectsNames []string `json:"projects_names"`
 }
+type BillingGroupStateType string
+
+const (
+	BillingGroupStateTypeActive  BillingGroupStateType = "active"
+	BillingGroupStateTypeDeleted BillingGroupStateType = "deleted"
+)
+
+func BillingGroupStateTypeChoices() []string {
+	return []string{"active", "deleted"}
+}
+
 type BillingGroupUpdateIn struct {
 	AccountId        string              `json:"account_id,omitempty"`
 	AddressLines     *[]string           `json:"address_lines,omitempty"`
@@ -373,26 +384,26 @@ type BillingGroupUpdateIn struct {
 	ZipCode          string              `json:"zip_code,omitempty"`
 }
 type BillingGroupUpdateOut struct {
-	AccountId             string            `json:"account_id"`
-	AccountName           string            `json:"account_name"`
-	AddressLines          []string          `json:"address_lines"`
-	BillingAddress        string            `json:"billing_address,omitempty"`
-	BillingCurrency       string            `json:"billing_currency"`
-	BillingEmails         []BillingEmailOut `json:"billing_emails"`
-	BillingExtraText      string            `json:"billing_extra_text"`
-	BillingGroupId        string            `json:"billing_group_id"`
-	BillingGroupName      string            `json:"billing_group_name"`
-	CardInfo              CardInfoOut       `json:"card_info"`
-	City                  string            `json:"city"`
-	Company               string            `json:"company"`
-	Country               string            `json:"country"`
-	CountryCode           string            `json:"country_code"`
-	EstimatedBalanceLocal string            `json:"estimated_balance_local"`
-	EstimatedBalanceUsd   string            `json:"estimated_balance_usd"`
-	PaymentMethod         string            `json:"payment_method"`
-	State                 string            `json:"state"`
-	VatId                 string            `json:"vat_id"`
-	ZipCode               string            `json:"zip_code"`
+	AccountId             string              `json:"account_id"`
+	AccountName           string              `json:"account_name"`
+	AddressLines          []string            `json:"address_lines"`
+	BillingAddress        string              `json:"billing_address,omitempty"`
+	BillingCurrency       BillingCurrencyType `json:"billing_currency"`
+	BillingEmails         []BillingEmailOut   `json:"billing_emails"`
+	BillingExtraText      string              `json:"billing_extra_text"`
+	BillingGroupId        string              `json:"billing_group_id"`
+	BillingGroupName      string              `json:"billing_group_name"`
+	CardInfo              CardInfoOut         `json:"card_info"`
+	City                  string              `json:"city"`
+	Company               string              `json:"company"`
+	Country               string              `json:"country"`
+	CountryCode           string              `json:"country_code"`
+	EstimatedBalanceLocal string              `json:"estimated_balance_local"`
+	EstimatedBalanceUsd   string              `json:"estimated_balance_usd"`
+	PaymentMethod         PaymentMethodType   `json:"payment_method"`
+	State                 string              `json:"state"`
+	VatId                 string              `json:"vat_id"`
+	ZipCode               string              `json:"zip_code"`
 }
 type CardInfoOut struct {
 	Brand       string `json:"brand"`
@@ -410,9 +421,52 @@ type CreditOut struct {
 	ExpireTime     *time.Time `json:"expire_time,omitempty"`
 	RemainingValue string     `json:"remaining_value,omitempty"`
 	StartTime      *time.Time `json:"start_time,omitempty"`
-	Type           string     `json:"type,omitempty"`
+	Type           CreditType `json:"type,omitempty"`
 	Value          string     `json:"value,omitempty"`
 }
+type CreditType string
+
+const (
+	CreditTypeDiscount    CreditType = "discount"
+	CreditTypeEmployee    CreditType = "employee"
+	CreditTypeEvaluation  CreditType = "evaluation"
+	CreditTypeInternal    CreditType = "internal"
+	CreditTypeOther       CreditType = "other"
+	CreditTypeOutage      CreditType = "outage"
+	CreditTypePartner     CreditType = "partner"
+	CreditTypePromotion   CreditType = "promotion"
+	CreditTypePurchase    CreditType = "purchase"
+	CreditTypeReferral    CreditType = "referral"
+	CreditTypeSponsorship CreditType = "sponsorship"
+	CreditTypeTrial       CreditType = "trial"
+	CreditTypeTrialOver   CreditType = "trial_over"
+)
+
+func CreditTypeChoices() []string {
+	return []string{"discount", "employee", "evaluation", "internal", "other", "outage", "partner", "promotion", "purchase", "referral", "sponsorship", "trial", "trial_over"}
+}
+
+type CurrencyType string
+
+const (
+	CurrencyTypeAud CurrencyType = "AUD"
+	CurrencyTypeCad CurrencyType = "CAD"
+	CurrencyTypeChf CurrencyType = "CHF"
+	CurrencyTypeDkk CurrencyType = "DKK"
+	CurrencyTypeEur CurrencyType = "EUR"
+	CurrencyTypeGbp CurrencyType = "GBP"
+	CurrencyTypeJpy CurrencyType = "JPY"
+	CurrencyTypeNok CurrencyType = "NOK"
+	CurrencyTypeNzd CurrencyType = "NZD"
+	CurrencyTypeSek CurrencyType = "SEK"
+	CurrencyTypeSgd CurrencyType = "SGD"
+	CurrencyTypeUsd CurrencyType = "USD"
+)
+
+func CurrencyTypeChoices() []string {
+	return []string{"AUD", "CAD", "CHF", "DKK", "EUR", "GBP", "JPY", "NOK", "NZD", "SEK", "SGD", "USD"}
+}
+
 type EventOut struct {
 	Actor          string     `json:"actor,omitempty"`
 	BillingGroupId string     `json:"billing_group_id,omitempty"`
@@ -424,19 +478,40 @@ type EventOut struct {
 	ProjectName    string     `json:"project_name,omitempty"`
 }
 type InvoiceOut struct {
-	BillingGroupId    string     `json:"billing_group_id"`
-	BillingGroupName  string     `json:"billing_group_name"`
-	BillingGroupState string     `json:"billing_group_state"`
-	Currency          string     `json:"currency"`
-	DownloadCookie    string     `json:"download_cookie"`
-	GeneratedAt       *time.Time `json:"generated_at,omitempty"`
-	InvoiceNumber     string     `json:"invoice_number"`
-	PeriodBegin       string     `json:"period_begin"`
-	PeriodEnd         string     `json:"period_end"`
-	State             string     `json:"state"`
-	TotalIncVat       string     `json:"total_inc_vat"`
-	TotalVatZero      string     `json:"total_vat_zero"`
+	BillingGroupId    string                `json:"billing_group_id"`
+	BillingGroupName  string                `json:"billing_group_name"`
+	BillingGroupState BillingGroupStateType `json:"billing_group_state"`
+	Currency          CurrencyType          `json:"currency"`
+	DownloadCookie    string                `json:"download_cookie"`
+	GeneratedAt       *time.Time            `json:"generated_at,omitempty"`
+	InvoiceNumber     string                `json:"invoice_number"`
+	PeriodBegin       string                `json:"period_begin"`
+	PeriodEnd         string                `json:"period_end"`
+	State             InvoiceStateType      `json:"state"`
+	TotalIncVat       string                `json:"total_inc_vat"`
+	TotalVatZero      string                `json:"total_vat_zero"`
 }
+type InvoiceStateType string
+
+const (
+	InvoiceStateTypeAccrual                InvoiceStateType = "accrual"
+	InvoiceStateTypeConsolidated           InvoiceStateType = "consolidated"
+	InvoiceStateTypeDue                    InvoiceStateType = "due"
+	InvoiceStateTypeEstimate               InvoiceStateType = "estimate"
+	InvoiceStateTypeFailedCreditCardCharge InvoiceStateType = "failed_credit_card_charge"
+	InvoiceStateTypeFailedNoCreditCard     InvoiceStateType = "failed_no_credit_card"
+	InvoiceStateTypeMailed                 InvoiceStateType = "mailed"
+	InvoiceStateTypeNoPaymentExpected      InvoiceStateType = "no_payment_expected"
+	InvoiceStateTypePaid                   InvoiceStateType = "paid"
+	InvoiceStateTypePartnerMetering        InvoiceStateType = "partner_metering"
+	InvoiceStateTypeUncollectible          InvoiceStateType = "uncollectible"
+	InvoiceStateTypeWaived                 InvoiceStateType = "waived"
+)
+
+func InvoiceStateTypeChoices() []string {
+	return []string{"accrual", "consolidated", "due", "estimate", "failed_credit_card_charge", "failed_no_credit_card", "mailed", "no_payment_expected", "paid", "partner_metering", "uncollectible", "waived"}
+}
+
 type LineOut struct {
 	CloudName            string            `json:"cloud_name,omitempty"`
 	CommitmentName       string            `json:"commitment_name,omitempty"`
@@ -444,21 +519,89 @@ type LineOut struct {
 	LinePreDiscountLocal string            `json:"line_pre_discount_local,omitempty"`
 	LineTotalLocal       string            `json:"line_total_local,omitempty"`
 	LineTotalUsd         string            `json:"line_total_usd"`
-	LineType             string            `json:"line_type"`
+	LineType             LineType          `json:"line_type"`
 	LocalCurrency        string            `json:"local_currency,omitempty"`
 	ProjectName          string            `json:"project_name,omitempty"`
 	ServiceName          string            `json:"service_name,omitempty"`
 	ServicePlan          string            `json:"service_plan,omitempty"`
-	ServiceType          string            `json:"service_type,omitempty"`
+	ServiceType          ServiceType       `json:"service_type,omitempty"`
 	Tags                 map[string]string `json:"tags,omitempty"`
 	TimestampBegin       string            `json:"timestamp_begin,omitempty"`
 	TimestampEnd         string            `json:"timestamp_end,omitempty"`
 }
+type LineType string
+
+const (
+	LineTypeCommitmentFee     LineType = "commitment_fee"
+	LineTypeCreditConsumption LineType = "credit_consumption"
+	LineTypeExtraCharge       LineType = "extra_charge"
+	LineTypeMultiplier        LineType = "multiplier"
+	LineTypeOtherEvent        LineType = "other_event"
+	LineTypeProPlatformCharge LineType = "pro_platform_charge"
+	LineTypeRounding          LineType = "rounding"
+	LineTypeServiceCharge     LineType = "service_charge"
+	LineTypeSupportCharge     LineType = "support_charge"
+)
+
+func LineTypeChoices() []string {
+	return []string{"commitment_fee", "credit_consumption", "extra_charge", "multiplier", "other_event", "pro_platform_charge", "rounding", "service_charge", "support_charge"}
+}
+
+type PaymentMethodType string
+
+const (
+	PaymentMethodTypeAccrual           PaymentMethodType = "accrual"
+	PaymentMethodTypeCard              PaymentMethodType = "card"
+	PaymentMethodTypeDisabled          PaymentMethodType = "disabled"
+	PaymentMethodTypeEmail             PaymentMethodType = "email"
+	PaymentMethodTypeNoPaymentExpected PaymentMethodType = "no_payment_expected"
+	PaymentMethodTypePartner           PaymentMethodType = "partner"
+)
+
+func PaymentMethodTypeChoices() []string {
+	return []string{"accrual", "card", "disabled", "email", "no_payment_expected", "partner"}
+}
+
 type ProjectOut struct {
 	AvailableCredits string `json:"available_credits"`
 	EstimatedBalance string `json:"estimated_balance"`
 	ProjectName      string `json:"project_name"`
 }
+type ServiceType string
+
+const (
+	ServiceTypeAlertmanager     ServiceType = "alertmanager"
+	ServiceTypeCassandra        ServiceType = "cassandra"
+	ServiceTypeClickhouse       ServiceType = "clickhouse"
+	ServiceTypeDragonfly        ServiceType = "dragonfly"
+	ServiceTypeElasticsearch    ServiceType = "elasticsearch"
+	ServiceTypeFlink            ServiceType = "flink"
+	ServiceTypeGrafana          ServiceType = "grafana"
+	ServiceTypeInfluxdb         ServiceType = "influxdb"
+	ServiceTypeKafka            ServiceType = "kafka"
+	ServiceTypeKafkaConnect     ServiceType = "kafka_connect"
+	ServiceTypeKafkaMirrormaker ServiceType = "kafka_mirrormaker"
+	ServiceTypeM3Aggregator     ServiceType = "m3aggregator"
+	ServiceTypeM3Db             ServiceType = "m3db"
+	ServiceTypeMysql            ServiceType = "mysql"
+	ServiceTypeOpensearch       ServiceType = "opensearch"
+	ServiceTypePg               ServiceType = "pg"
+	ServiceTypeRedis            ServiceType = "redis"
+	ServiceTypeStresstester     ServiceType = "stresstester"
+	ServiceTypeSw               ServiceType = "sw"
+	ServiceTypeThanos           ServiceType = "thanos"
+	ServiceTypeThanoscompactor  ServiceType = "thanoscompactor"
+	ServiceTypeThanosquery      ServiceType = "thanosquery"
+	ServiceTypeThanosreceiver   ServiceType = "thanosreceiver"
+	ServiceTypeThanosstore      ServiceType = "thanosstore"
+	ServiceTypeVector           ServiceType = "vector"
+	ServiceTypeVmalert          ServiceType = "vmalert"
+)
+
+func ServiceTypeChoices() []string {
+	return []string{"alertmanager", "cassandra", "clickhouse", "dragonfly", "elasticsearch", "flink", "grafana", "influxdb", "kafka", "kafka_connect", "kafka_mirrormaker", "m3aggregator", "m3db", "mysql", "opensearch", "pg", "redis", "stresstester", "sw", "thanos", "thanoscompactor", "thanosquery", "thanosreceiver", "thanosstore", "vector", "vmalert"}
+}
+
 type billingGroupCreateOut struct {
 	BillingGroup BillingGroupCreateOut `json:"billing_group"`
 }

--- a/handler/clickhouse/clickhouse.go
+++ b/handler/clickhouse/clickhouse.go
@@ -102,6 +102,7 @@ type ServiceClickHouseDatabaseCreateIn struct {
 type ServiceClickHouseTieredStorageSummaryOut struct {
 	CurrentCost         string                 `json:"current_cost"`
 	ForecastedCost      string                 `json:"forecasted_cost"`
+	ForecastedRate      string                 `json:"forecasted_rate,omitempty"`
 	StorageUsageHistory StorageUsageHistoryOut `json:"storage_usage_history"`
 	TotalStorageUsage   int                    `json:"total_storage_usage"`
 }

--- a/handler/domain/domain.go
+++ b/handler/domain/domain.go
@@ -107,47 +107,87 @@ func (h *DomainHandler) OrganizationDomainsRemove(ctx context.Context, organizat
 }
 
 type DomainOut struct {
-	ChallengeToken   string    `json:"challenge_token"`
-	CreateTime       time.Time `json:"create_time"`
-	DomainId         string    `json:"domain_id"`
-	DomainName       string    `json:"domain_name"`
-	OrganizationId   string    `json:"organization_id"`
-	State            string    `json:"state"`
-	VerificationType string    `json:"verification_type"`
+	ChallengeToken                string           `json:"challenge_token"`
+	CreateTime                    time.Time        `json:"create_time"`
+	DomainId                      string           `json:"domain_id"`
+	DomainName                    string           `json:"domain_name"`
+	LinkedAuthenticationMethodIds []string         `json:"linked_authentication_method_ids"`
+	OrganizationId                string           `json:"organization_id"`
+	State                         DomainStateType  `json:"state"`
+	VerificationType              VerificationType `json:"verification_type"`
 }
+type DomainStateType string
+
+const (
+	DomainStateTypeDeleted    DomainStateType = "deleted"
+	DomainStateTypeUnverified DomainStateType = "unverified"
+	DomainStateTypeVerified   DomainStateType = "verified"
+)
+
+func DomainStateTypeChoices() []string {
+	return []string{"deleted", "unverified", "verified"}
+}
+
 type OrganizationDomainAddIn struct {
 	DomainName       string           `json:"domain_name"`
 	VerificationType VerificationType `json:"verification_type"`
 }
 type OrganizationDomainAddOut struct {
-	ChallengeToken   string    `json:"challenge_token"`
-	CreateTime       time.Time `json:"create_time"`
-	DomainId         string    `json:"domain_id"`
-	DomainName       string    `json:"domain_name"`
-	OrganizationId   string    `json:"organization_id"`
-	State            string    `json:"state"`
-	VerificationType string    `json:"verification_type"`
+	ChallengeToken                string                         `json:"challenge_token"`
+	CreateTime                    time.Time                      `json:"create_time"`
+	DomainId                      string                         `json:"domain_id"`
+	DomainName                    string                         `json:"domain_name"`
+	LinkedAuthenticationMethodIds []string                       `json:"linked_authentication_method_ids"`
+	OrganizationId                string                         `json:"organization_id"`
+	State                         OrganizationDomainAddStateType `json:"state"`
+	VerificationType              VerificationType               `json:"verification_type"`
 }
+type OrganizationDomainAddStateType string
+
+const (
+	OrganizationDomainAddStateTypeDeleted    OrganizationDomainAddStateType = "deleted"
+	OrganizationDomainAddStateTypeUnverified OrganizationDomainAddStateType = "unverified"
+	OrganizationDomainAddStateTypeVerified   OrganizationDomainAddStateType = "verified"
+)
+
+func OrganizationDomainAddStateTypeChoices() []string {
+	return []string{"deleted", "unverified", "verified"}
+}
+
+type OrganizationDomainStateType string
+
+const (
+	OrganizationDomainStateTypeDeleted    OrganizationDomainStateType = "deleted"
+	OrganizationDomainStateTypeUnverified OrganizationDomainStateType = "unverified"
+	OrganizationDomainStateTypeVerified   OrganizationDomainStateType = "verified"
+)
+
+func OrganizationDomainStateTypeChoices() []string {
+	return []string{"deleted", "unverified", "verified"}
+}
+
 type OrganizationDomainUpdateIn struct {
 	VerificationType VerificationType `json:"verification_type,omitempty"`
 }
 type OrganizationDomainUpdateOut struct {
-	ChallengeToken   string    `json:"challenge_token"`
-	CreateTime       time.Time `json:"create_time"`
-	DomainId         string    `json:"domain_id"`
-	DomainName       string    `json:"domain_name"`
-	OrganizationId   string    `json:"organization_id"`
-	State            string    `json:"state"`
-	VerificationType string    `json:"verification_type"`
+	ChallengeToken                string                      `json:"challenge_token"`
+	CreateTime                    time.Time                   `json:"create_time"`
+	DomainId                      string                      `json:"domain_id"`
+	DomainName                    string                      `json:"domain_name"`
+	LinkedAuthenticationMethodIds []string                    `json:"linked_authentication_method_ids"`
+	OrganizationId                string                      `json:"organization_id"`
+	State                         OrganizationDomainStateType `json:"state"`
+	VerificationType              VerificationType            `json:"verification_type"`
 }
 type OrganizationDomainVerifyOut struct {
-	ChallengeToken   string    `json:"challenge_token"`
-	CreateTime       time.Time `json:"create_time"`
-	DomainId         string    `json:"domain_id"`
-	DomainName       string    `json:"domain_name"`
-	OrganizationId   string    `json:"organization_id"`
-	State            string    `json:"state"`
-	VerificationType string    `json:"verification_type"`
+	ChallengeToken                string                      `json:"challenge_token"`
+	CreateTime                    time.Time                   `json:"create_time"`
+	DomainId                      string                      `json:"domain_id"`
+	DomainName                    string                      `json:"domain_name"`
+	LinkedAuthenticationMethodIds []string                    `json:"linked_authentication_method_ids"`
+	OrganizationId                string                      `json:"organization_id"`
+	State                         OrganizationDomainStateType `json:"state"`
+	VerificationType              VerificationType            `json:"verification_type"`
 }
 type VerificationType string
 

--- a/handler/flinkapplication/flinkapplication.go
+++ b/handler/flinkapplication/flinkapplication.go
@@ -145,18 +145,44 @@ type ColumnOut struct {
 	Watermark string `json:"watermark,omitempty"`
 }
 type CurrentDeploymentOut struct {
-	CreatedAt         time.Time `json:"created_at"`
-	CreatedBy         string    `json:"created_by"`
-	ErrorMsg          string    `json:"error_msg,omitempty"`
-	Id                string    `json:"id"`
-	JobId             string    `json:"job_id,omitempty"`
-	LastSavepoint     string    `json:"last_savepoint,omitempty"`
-	Parallelism       int       `json:"parallelism"`
-	RestartEnabled    bool      `json:"restart_enabled"`
-	StartingSavepoint string    `json:"starting_savepoint,omitempty"`
-	Status            string    `json:"status"`
-	VersionId         string    `json:"version_id"`
+	CreatedAt         time.Time                   `json:"created_at"`
+	CreatedBy         string                      `json:"created_by"`
+	ErrorMsg          string                      `json:"error_msg,omitempty"`
+	Id                string                      `json:"id"`
+	JobId             string                      `json:"job_id,omitempty"`
+	LastSavepoint     string                      `json:"last_savepoint,omitempty"`
+	Parallelism       int                         `json:"parallelism"`
+	RestartEnabled    bool                        `json:"restart_enabled"`
+	StartingSavepoint string                      `json:"starting_savepoint,omitempty"`
+	Status            CurrentDeploymentStatusType `json:"status"`
+	VersionId         string                      `json:"version_id"`
 }
+type CurrentDeploymentStatusType string
+
+const (
+	CurrentDeploymentStatusTypeInitializing           CurrentDeploymentStatusType = "INITIALIZING"
+	CurrentDeploymentStatusTypeCreated                CurrentDeploymentStatusType = "CREATED"
+	CurrentDeploymentStatusTypeRunning                CurrentDeploymentStatusType = "RUNNING"
+	CurrentDeploymentStatusTypeFailing                CurrentDeploymentStatusType = "FAILING"
+	CurrentDeploymentStatusTypeFailed                 CurrentDeploymentStatusType = "FAILED"
+	CurrentDeploymentStatusTypeSaving                 CurrentDeploymentStatusType = "SAVING"
+	CurrentDeploymentStatusTypeCancellingRequested    CurrentDeploymentStatusType = "CANCELLING_REQUESTED"
+	CurrentDeploymentStatusTypeCancelling             CurrentDeploymentStatusType = "CANCELLING"
+	CurrentDeploymentStatusTypeCanceled               CurrentDeploymentStatusType = "CANCELED"
+	CurrentDeploymentStatusTypeSavingAndStopRequested CurrentDeploymentStatusType = "SAVING_AND_STOP_REQUESTED"
+	CurrentDeploymentStatusTypeSavingAndStop          CurrentDeploymentStatusType = "SAVING_AND_STOP"
+	CurrentDeploymentStatusTypeFinished               CurrentDeploymentStatusType = "FINISHED"
+	CurrentDeploymentStatusTypeRestarting             CurrentDeploymentStatusType = "RESTARTING"
+	CurrentDeploymentStatusTypeSuspended              CurrentDeploymentStatusType = "SUSPENDED"
+	CurrentDeploymentStatusTypeDeleteRequested        CurrentDeploymentStatusType = "DELETE_REQUESTED"
+	CurrentDeploymentStatusTypeDeleting               CurrentDeploymentStatusType = "DELETING"
+	CurrentDeploymentStatusTypeReconciling            CurrentDeploymentStatusType = "RECONCILING"
+)
+
+func CurrentDeploymentStatusTypeChoices() []string {
+	return []string{"INITIALIZING", "CREATED", "RUNNING", "FAILING", "FAILED", "SAVING", "CANCELLING_REQUESTED", "CANCELLING", "CANCELED", "SAVING_AND_STOP_REQUESTED", "SAVING_AND_STOP", "FINISHED", "RESTARTING", "SUSPENDED", "DELETE_REQUESTED", "DELETING", "RECONCILING"}
+}
+
 type ServiceFlinkCreateApplicationIn struct {
 	ApplicationVersion *ApplicationVersionIn `json:"application_version,omitempty"`
 	Name               string                `json:"name"`

--- a/handler/flinkapplicationdeployment/flinkapplicationdeployment.go
+++ b/handler/flinkapplicationdeployment/flinkapplicationdeployment.go
@@ -133,30 +133,82 @@ func (h *FlinkApplicationDeploymentHandler) ServiceFlinkStopApplicationDeploymen
 }
 
 type DeploymentOut struct {
-	CreatedAt         time.Time `json:"created_at"`
-	CreatedBy         string    `json:"created_by"`
-	ErrorMsg          string    `json:"error_msg,omitempty"`
-	Id                string    `json:"id"`
-	JobId             string    `json:"job_id,omitempty"`
-	LastSavepoint     string    `json:"last_savepoint,omitempty"`
-	Parallelism       int       `json:"parallelism"`
-	RestartEnabled    bool      `json:"restart_enabled"`
-	StartingSavepoint string    `json:"starting_savepoint,omitempty"`
-	Status            string    `json:"status"`
-	VersionId         string    `json:"version_id"`
+	CreatedAt         time.Time            `json:"created_at"`
+	CreatedBy         string               `json:"created_by"`
+	ErrorMsg          string               `json:"error_msg,omitempty"`
+	Id                string               `json:"id"`
+	JobId             string               `json:"job_id,omitempty"`
+	LastSavepoint     string               `json:"last_savepoint,omitempty"`
+	Parallelism       int                  `json:"parallelism"`
+	RestartEnabled    bool                 `json:"restart_enabled"`
+	StartingSavepoint string               `json:"starting_savepoint,omitempty"`
+	Status            DeploymentStatusType `json:"status"`
+	VersionId         string               `json:"version_id"`
 }
+type DeploymentStatusType string
+
+const (
+	DeploymentStatusTypeInitializing           DeploymentStatusType = "INITIALIZING"
+	DeploymentStatusTypeCreated                DeploymentStatusType = "CREATED"
+	DeploymentStatusTypeRunning                DeploymentStatusType = "RUNNING"
+	DeploymentStatusTypeFailing                DeploymentStatusType = "FAILING"
+	DeploymentStatusTypeFailed                 DeploymentStatusType = "FAILED"
+	DeploymentStatusTypeSaving                 DeploymentStatusType = "SAVING"
+	DeploymentStatusTypeCancellingRequested    DeploymentStatusType = "CANCELLING_REQUESTED"
+	DeploymentStatusTypeCancelling             DeploymentStatusType = "CANCELLING"
+	DeploymentStatusTypeCanceled               DeploymentStatusType = "CANCELED"
+	DeploymentStatusTypeSavingAndStopRequested DeploymentStatusType = "SAVING_AND_STOP_REQUESTED"
+	DeploymentStatusTypeSavingAndStop          DeploymentStatusType = "SAVING_AND_STOP"
+	DeploymentStatusTypeFinished               DeploymentStatusType = "FINISHED"
+	DeploymentStatusTypeRestarting             DeploymentStatusType = "RESTARTING"
+	DeploymentStatusTypeSuspended              DeploymentStatusType = "SUSPENDED"
+	DeploymentStatusTypeDeleteRequested        DeploymentStatusType = "DELETE_REQUESTED"
+	DeploymentStatusTypeDeleting               DeploymentStatusType = "DELETING"
+	DeploymentStatusTypeReconciling            DeploymentStatusType = "RECONCILING"
+)
+
+func DeploymentStatusTypeChoices() []string {
+	return []string{"INITIALIZING", "CREATED", "RUNNING", "FAILING", "FAILED", "SAVING", "CANCELLING_REQUESTED", "CANCELLING", "CANCELED", "SAVING_AND_STOP_REQUESTED", "SAVING_AND_STOP", "FINISHED", "RESTARTING", "SUSPENDED", "DELETE_REQUESTED", "DELETING", "RECONCILING"}
+}
+
+type ServiceFlinkApplicationDeploymentStatusType string
+
+const (
+	ServiceFlinkApplicationDeploymentStatusTypeInitializing           ServiceFlinkApplicationDeploymentStatusType = "INITIALIZING"
+	ServiceFlinkApplicationDeploymentStatusTypeCreated                ServiceFlinkApplicationDeploymentStatusType = "CREATED"
+	ServiceFlinkApplicationDeploymentStatusTypeRunning                ServiceFlinkApplicationDeploymentStatusType = "RUNNING"
+	ServiceFlinkApplicationDeploymentStatusTypeFailing                ServiceFlinkApplicationDeploymentStatusType = "FAILING"
+	ServiceFlinkApplicationDeploymentStatusTypeFailed                 ServiceFlinkApplicationDeploymentStatusType = "FAILED"
+	ServiceFlinkApplicationDeploymentStatusTypeSaving                 ServiceFlinkApplicationDeploymentStatusType = "SAVING"
+	ServiceFlinkApplicationDeploymentStatusTypeCancellingRequested    ServiceFlinkApplicationDeploymentStatusType = "CANCELLING_REQUESTED"
+	ServiceFlinkApplicationDeploymentStatusTypeCancelling             ServiceFlinkApplicationDeploymentStatusType = "CANCELLING"
+	ServiceFlinkApplicationDeploymentStatusTypeCanceled               ServiceFlinkApplicationDeploymentStatusType = "CANCELED"
+	ServiceFlinkApplicationDeploymentStatusTypeSavingAndStopRequested ServiceFlinkApplicationDeploymentStatusType = "SAVING_AND_STOP_REQUESTED"
+	ServiceFlinkApplicationDeploymentStatusTypeSavingAndStop          ServiceFlinkApplicationDeploymentStatusType = "SAVING_AND_STOP"
+	ServiceFlinkApplicationDeploymentStatusTypeFinished               ServiceFlinkApplicationDeploymentStatusType = "FINISHED"
+	ServiceFlinkApplicationDeploymentStatusTypeRestarting             ServiceFlinkApplicationDeploymentStatusType = "RESTARTING"
+	ServiceFlinkApplicationDeploymentStatusTypeSuspended              ServiceFlinkApplicationDeploymentStatusType = "SUSPENDED"
+	ServiceFlinkApplicationDeploymentStatusTypeDeleteRequested        ServiceFlinkApplicationDeploymentStatusType = "DELETE_REQUESTED"
+	ServiceFlinkApplicationDeploymentStatusTypeDeleting               ServiceFlinkApplicationDeploymentStatusType = "DELETING"
+	ServiceFlinkApplicationDeploymentStatusTypeReconciling            ServiceFlinkApplicationDeploymentStatusType = "RECONCILING"
+)
+
+func ServiceFlinkApplicationDeploymentStatusTypeChoices() []string {
+	return []string{"INITIALIZING", "CREATED", "RUNNING", "FAILING", "FAILED", "SAVING", "CANCELLING_REQUESTED", "CANCELLING", "CANCELED", "SAVING_AND_STOP_REQUESTED", "SAVING_AND_STOP", "FINISHED", "RESTARTING", "SUSPENDED", "DELETE_REQUESTED", "DELETING", "RECONCILING"}
+}
+
 type ServiceFlinkCancelApplicationDeploymentOut struct {
-	CreatedAt         time.Time `json:"created_at"`
-	CreatedBy         string    `json:"created_by"`
-	ErrorMsg          string    `json:"error_msg,omitempty"`
-	Id                string    `json:"id"`
-	JobId             string    `json:"job_id,omitempty"`
-	LastSavepoint     string    `json:"last_savepoint,omitempty"`
-	Parallelism       int       `json:"parallelism"`
-	RestartEnabled    bool      `json:"restart_enabled"`
-	StartingSavepoint string    `json:"starting_savepoint,omitempty"`
-	Status            string    `json:"status"`
-	VersionId         string    `json:"version_id"`
+	CreatedAt         time.Time                                   `json:"created_at"`
+	CreatedBy         string                                      `json:"created_by"`
+	ErrorMsg          string                                      `json:"error_msg,omitempty"`
+	Id                string                                      `json:"id"`
+	JobId             string                                      `json:"job_id,omitempty"`
+	LastSavepoint     string                                      `json:"last_savepoint,omitempty"`
+	Parallelism       int                                         `json:"parallelism"`
+	RestartEnabled    bool                                        `json:"restart_enabled"`
+	StartingSavepoint string                                      `json:"starting_savepoint,omitempty"`
+	Status            ServiceFlinkApplicationDeploymentStatusType `json:"status"`
+	VersionId         string                                      `json:"version_id"`
 }
 type ServiceFlinkCreateApplicationDeploymentIn struct {
 	Parallelism       *int   `json:"parallelism,omitempty"`
@@ -165,56 +217,56 @@ type ServiceFlinkCreateApplicationDeploymentIn struct {
 	VersionId         string `json:"version_id"`
 }
 type ServiceFlinkCreateApplicationDeploymentOut struct {
-	CreatedAt         time.Time `json:"created_at"`
-	CreatedBy         string    `json:"created_by"`
-	ErrorMsg          string    `json:"error_msg,omitempty"`
-	Id                string    `json:"id"`
-	JobId             string    `json:"job_id,omitempty"`
-	LastSavepoint     string    `json:"last_savepoint,omitempty"`
-	Parallelism       int       `json:"parallelism"`
-	RestartEnabled    bool      `json:"restart_enabled"`
-	StartingSavepoint string    `json:"starting_savepoint,omitempty"`
-	Status            string    `json:"status"`
-	VersionId         string    `json:"version_id"`
+	CreatedAt         time.Time                                   `json:"created_at"`
+	CreatedBy         string                                      `json:"created_by"`
+	ErrorMsg          string                                      `json:"error_msg,omitempty"`
+	Id                string                                      `json:"id"`
+	JobId             string                                      `json:"job_id,omitempty"`
+	LastSavepoint     string                                      `json:"last_savepoint,omitempty"`
+	Parallelism       int                                         `json:"parallelism"`
+	RestartEnabled    bool                                        `json:"restart_enabled"`
+	StartingSavepoint string                                      `json:"starting_savepoint,omitempty"`
+	Status            ServiceFlinkApplicationDeploymentStatusType `json:"status"`
+	VersionId         string                                      `json:"version_id"`
 }
 type ServiceFlinkDeleteApplicationDeploymentOut struct {
-	CreatedAt         time.Time `json:"created_at"`
-	CreatedBy         string    `json:"created_by"`
-	ErrorMsg          string    `json:"error_msg,omitempty"`
-	Id                string    `json:"id"`
-	JobId             string    `json:"job_id,omitempty"`
-	LastSavepoint     string    `json:"last_savepoint,omitempty"`
-	Parallelism       int       `json:"parallelism"`
-	RestartEnabled    bool      `json:"restart_enabled"`
-	StartingSavepoint string    `json:"starting_savepoint,omitempty"`
-	Status            string    `json:"status"`
-	VersionId         string    `json:"version_id"`
+	CreatedAt         time.Time                                   `json:"created_at"`
+	CreatedBy         string                                      `json:"created_by"`
+	ErrorMsg          string                                      `json:"error_msg,omitempty"`
+	Id                string                                      `json:"id"`
+	JobId             string                                      `json:"job_id,omitempty"`
+	LastSavepoint     string                                      `json:"last_savepoint,omitempty"`
+	Parallelism       int                                         `json:"parallelism"`
+	RestartEnabled    bool                                        `json:"restart_enabled"`
+	StartingSavepoint string                                      `json:"starting_savepoint,omitempty"`
+	Status            ServiceFlinkApplicationDeploymentStatusType `json:"status"`
+	VersionId         string                                      `json:"version_id"`
 }
 type ServiceFlinkGetApplicationDeploymentOut struct {
-	CreatedAt         time.Time `json:"created_at"`
-	CreatedBy         string    `json:"created_by"`
-	ErrorMsg          string    `json:"error_msg,omitempty"`
-	Id                string    `json:"id"`
-	JobId             string    `json:"job_id,omitempty"`
-	LastSavepoint     string    `json:"last_savepoint,omitempty"`
-	Parallelism       int       `json:"parallelism"`
-	RestartEnabled    bool      `json:"restart_enabled"`
-	StartingSavepoint string    `json:"starting_savepoint,omitempty"`
-	Status            string    `json:"status"`
-	VersionId         string    `json:"version_id"`
+	CreatedAt         time.Time                                   `json:"created_at"`
+	CreatedBy         string                                      `json:"created_by"`
+	ErrorMsg          string                                      `json:"error_msg,omitempty"`
+	Id                string                                      `json:"id"`
+	JobId             string                                      `json:"job_id,omitempty"`
+	LastSavepoint     string                                      `json:"last_savepoint,omitempty"`
+	Parallelism       int                                         `json:"parallelism"`
+	RestartEnabled    bool                                        `json:"restart_enabled"`
+	StartingSavepoint string                                      `json:"starting_savepoint,omitempty"`
+	Status            ServiceFlinkApplicationDeploymentStatusType `json:"status"`
+	VersionId         string                                      `json:"version_id"`
 }
 type ServiceFlinkStopApplicationDeploymentOut struct {
-	CreatedAt         time.Time `json:"created_at"`
-	CreatedBy         string    `json:"created_by"`
-	ErrorMsg          string    `json:"error_msg,omitempty"`
-	Id                string    `json:"id"`
-	JobId             string    `json:"job_id,omitempty"`
-	LastSavepoint     string    `json:"last_savepoint,omitempty"`
-	Parallelism       int       `json:"parallelism"`
-	RestartEnabled    bool      `json:"restart_enabled"`
-	StartingSavepoint string    `json:"starting_savepoint,omitempty"`
-	Status            string    `json:"status"`
-	VersionId         string    `json:"version_id"`
+	CreatedAt         time.Time                                   `json:"created_at"`
+	CreatedBy         string                                      `json:"created_by"`
+	ErrorMsg          string                                      `json:"error_msg,omitempty"`
+	Id                string                                      `json:"id"`
+	JobId             string                                      `json:"job_id,omitempty"`
+	LastSavepoint     string                                      `json:"last_savepoint,omitempty"`
+	Parallelism       int                                         `json:"parallelism"`
+	RestartEnabled    bool                                        `json:"restart_enabled"`
+	StartingSavepoint string                                      `json:"starting_savepoint,omitempty"`
+	Status            ServiceFlinkApplicationDeploymentStatusType `json:"status"`
+	VersionId         string                                      `json:"version_id"`
 }
 type serviceFlinkListApplicationDeploymentsOut struct {
 	Deployments []DeploymentOut `json:"deployments"`

--- a/handler/flinkjob/flinkjob.go
+++ b/handler/flinkjob/flinkjob.go
@@ -60,24 +60,64 @@ func (h *FlinkJobHandler) ServiceFlinkJobsList(ctx context.Context, project stri
 }
 
 type JobOut struct {
-	Id     string `json:"id,omitempty"`
-	Status string `json:"status,omitempty"`
+	Id     string        `json:"id,omitempty"`
+	Status JobStatusType `json:"status,omitempty"`
 }
+type JobStatusType string
+
+const (
+	JobStatusTypeInitializing JobStatusType = "INITIALIZING"
+	JobStatusTypeCreated      JobStatusType = "CREATED"
+	JobStatusTypeRunning      JobStatusType = "RUNNING"
+	JobStatusTypeFailing      JobStatusType = "FAILING"
+	JobStatusTypeFailed       JobStatusType = "FAILED"
+	JobStatusTypeCancelling   JobStatusType = "CANCELLING"
+	JobStatusTypeCanceled     JobStatusType = "CANCELED"
+	JobStatusTypeFinished     JobStatusType = "FINISHED"
+	JobStatusTypeRestarting   JobStatusType = "RESTARTING"
+	JobStatusTypeSuspended    JobStatusType = "SUSPENDED"
+	JobStatusTypeReconciling  JobStatusType = "RECONCILING"
+)
+
+func JobStatusTypeChoices() []string {
+	return []string{"INITIALIZING", "CREATED", "RUNNING", "FAILING", "FAILED", "CANCELLING", "CANCELED", "FINISHED", "RESTARTING", "SUSPENDED", "RECONCILING"}
+}
+
 type ServiceFlinkJobDetailsOut struct {
-	Duration       *int             `json:"duration,omitempty"`
-	EndTime        *int             `json:"end-time,omitempty"`
-	IsStoppable    *bool            `json:"isStoppable,omitempty"`
-	Jid            string           `json:"jid,omitempty"`
-	MaxParallelism *int             `json:"maxParallelism,omitempty"`
-	Name           string           `json:"name,omitempty"`
-	Now            *int             `json:"now,omitempty"`
-	Plan           map[string]any   `json:"plan,omitempty"`
-	StartTime      *int             `json:"start-time,omitempty"`
-	State          string           `json:"state,omitempty"`
-	StatusCounts   *StatusCountsOut `json:"status-counts,omitempty"`
-	Timestamps     map[string]any   `json:"timestamps,omitempty"`
-	Vertices       []map[string]any `json:"vertices,omitempty"`
+	Duration       *int                            `json:"duration,omitempty"`
+	EndTime        *int                            `json:"end-time,omitempty"`
+	IsStoppable    *bool                           `json:"isStoppable,omitempty"`
+	Jid            string                          `json:"jid,omitempty"`
+	MaxParallelism *int                            `json:"maxParallelism,omitempty"`
+	Name           string                          `json:"name,omitempty"`
+	Now            *int                            `json:"now,omitempty"`
+	Plan           map[string]any                  `json:"plan,omitempty"`
+	StartTime      *int                            `json:"start-time,omitempty"`
+	State          ServiceFlinkJobDetailsStateType `json:"state,omitempty"`
+	StatusCounts   *StatusCountsOut                `json:"status-counts,omitempty"`
+	Timestamps     map[string]any                  `json:"timestamps,omitempty"`
+	Vertices       []map[string]any                `json:"vertices,omitempty"`
 }
+type ServiceFlinkJobDetailsStateType string
+
+const (
+	ServiceFlinkJobDetailsStateTypeInitializing ServiceFlinkJobDetailsStateType = "INITIALIZING"
+	ServiceFlinkJobDetailsStateTypeCreated      ServiceFlinkJobDetailsStateType = "CREATED"
+	ServiceFlinkJobDetailsStateTypeRunning      ServiceFlinkJobDetailsStateType = "RUNNING"
+	ServiceFlinkJobDetailsStateTypeFailing      ServiceFlinkJobDetailsStateType = "FAILING"
+	ServiceFlinkJobDetailsStateTypeFailed       ServiceFlinkJobDetailsStateType = "FAILED"
+	ServiceFlinkJobDetailsStateTypeCancelling   ServiceFlinkJobDetailsStateType = "CANCELLING"
+	ServiceFlinkJobDetailsStateTypeCanceled     ServiceFlinkJobDetailsStateType = "CANCELED"
+	ServiceFlinkJobDetailsStateTypeFinished     ServiceFlinkJobDetailsStateType = "FINISHED"
+	ServiceFlinkJobDetailsStateTypeRestarting   ServiceFlinkJobDetailsStateType = "RESTARTING"
+	ServiceFlinkJobDetailsStateTypeSuspended    ServiceFlinkJobDetailsStateType = "SUSPENDED"
+	ServiceFlinkJobDetailsStateTypeReconciling  ServiceFlinkJobDetailsStateType = "RECONCILING"
+)
+
+func ServiceFlinkJobDetailsStateTypeChoices() []string {
+	return []string{"INITIALIZING", "CREATED", "RUNNING", "FAILING", "FAILED", "CANCELLING", "CANCELED", "FINISHED", "RESTARTING", "SUSPENDED", "RECONCILING"}
+}
+
 type StatusCountsOut struct {
 	Canceled     *int `json:"CANCELED,omitempty"`
 	Canceling    *int `json:"CANCELING,omitempty"`

--- a/handler/kafka/kafka.go
+++ b/handler/kafka/kafka.go
@@ -153,7 +153,7 @@ func (h *KafkaHandler) ServiceKafkaTieredStorageStorageUsageByTopic(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	out := new(serviceKafkaTieredStorageStorageUsageByTopicOut)
+	out := new(serviceKafkaTieredStorageUsageByTopicOut)
 	err = json.Unmarshal(b, out)
 	if err != nil {
 		return nil, err
@@ -166,7 +166,7 @@ func (h *KafkaHandler) ServiceKafkaTieredStorageStorageUsageTotal(ctx context.Co
 	if err != nil {
 		return 0, err
 	}
-	out := new(serviceKafkaTieredStorageStorageUsageTotalOut)
+	out := new(serviceKafkaTieredStorageUsageTotalOut)
 	err = json.Unmarshal(b, out)
 	if err != nil {
 		return 0, err
@@ -188,10 +188,10 @@ func (h *KafkaHandler) ServiceKafkaTieredStorageSummary(ctx context.Context, pro
 }
 
 type AclOut struct {
-	Id         string `json:"id,omitempty"`
-	Permission string `json:"permission"`
-	Topic      string `json:"topic"`
-	Username   string `json:"username"`
+	Id         string         `json:"id,omitempty"`
+	Permission PermissionType `json:"permission"`
+	Topic      string         `json:"topic"`
+	Username   string         `json:"username"`
 }
 type HourlyOut struct {
 	EstimatedCost   string `json:"estimated_cost,omitempty"`
@@ -240,6 +240,7 @@ type ServiceKafkaQuotaDescribeOut struct {
 type ServiceKafkaTieredStorageSummaryOut struct {
 	CurrentCost         string                 `json:"current_cost"`
 	ForecastedCost      string                 `json:"forecasted_cost"`
+	ForecastedRate      string                 `json:"forecasted_rate,omitempty"`
 	StorageUsageHistory StorageUsageHistoryOut `json:"storage_usage_history"`
 	TotalStorageUsage   int                    `json:"total_storage_usage"`
 }
@@ -261,9 +262,9 @@ type serviceKafkaQuotaDescribeOut struct {
 type serviceKafkaQuotaListOut struct {
 	Quotas []QuotaOut `json:"quotas"`
 }
-type serviceKafkaTieredStorageStorageUsageByTopicOut struct {
+type serviceKafkaTieredStorageUsageByTopicOut struct {
 	StorageUsage map[string]any `json:"storage_usage"`
 }
-type serviceKafkaTieredStorageStorageUsageTotalOut struct {
+type serviceKafkaTieredStorageUsageTotalOut struct {
 	TotalStorageUsage int `json:"total_storage_usage"`
 }

--- a/handler/kafkaconnect/kafkaconnect.go
+++ b/handler/kafkaconnect/kafkaconnect.go
@@ -186,33 +186,88 @@ type ConfigOut struct {
 	Name           string `json:"name"`
 }
 type ConfigurationSchemaOut struct {
-	DefaultValue  string `json:"default_value"`
-	DisplayName   string `json:"display_name"`
-	Documentation string `json:"documentation"`
-	Group         string `json:"group"`
-	Importance    string `json:"importance"`
-	Name          string `json:"name"`
-	Order         int    `json:"order"`
-	Required      bool   `json:"required"`
-	Type          string `json:"type"`
-	Width         string `json:"width"`
+	DefaultValue  string                  `json:"default_value"`
+	DisplayName   string                  `json:"display_name"`
+	Documentation string                  `json:"documentation"`
+	Group         string                  `json:"group"`
+	Importance    ImportanceType          `json:"importance"`
+	Name          string                  `json:"name"`
+	Order         int                     `json:"order"`
+	Required      bool                    `json:"required"`
+	Type          ConfigurationSchemaType `json:"type"`
+	Width         WidthType               `json:"width"`
 }
+type ConfigurationSchemaType string
+
+const (
+	ConfigurationSchemaTypeString   ConfigurationSchemaType = "STRING"
+	ConfigurationSchemaTypeInt      ConfigurationSchemaType = "INT"
+	ConfigurationSchemaTypeShort    ConfigurationSchemaType = "SHORT"
+	ConfigurationSchemaTypeLong     ConfigurationSchemaType = "LONG"
+	ConfigurationSchemaTypeDouble   ConfigurationSchemaType = "DOUBLE"
+	ConfigurationSchemaTypeBoolean  ConfigurationSchemaType = "BOOLEAN"
+	ConfigurationSchemaTypeList     ConfigurationSchemaType = "LIST"
+	ConfigurationSchemaTypeClass    ConfigurationSchemaType = "CLASS"
+	ConfigurationSchemaTypePassword ConfigurationSchemaType = "PASSWORD"
+)
+
+func ConfigurationSchemaTypeChoices() []string {
+	return []string{"STRING", "INT", "SHORT", "LONG", "DOUBLE", "BOOLEAN", "LIST", "CLASS", "PASSWORD"}
+}
+
 type ConnectorOut struct {
 	Config ConfigOut `json:"config"`
 	Name   string    `json:"name"`
 	Plugin PluginOut `json:"plugin"`
 	Tasks  []TaskOut `json:"tasks"`
 }
-type PluginOut struct {
-	Author      string `json:"author"`
-	Class       string `json:"class"`
-	DocUrl      string `json:"docURL"`
-	Preview     *bool  `json:"preview,omitempty"`
-	PreviewInfo string `json:"preview_info,omitempty"`
-	Title       string `json:"title"`
-	Type        string `json:"type"`
-	Version     string `json:"version"`
+type ImportanceType string
+
+const (
+	ImportanceTypeLow    ImportanceType = "LOW"
+	ImportanceTypeMedium ImportanceType = "MEDIUM"
+	ImportanceTypeHigh   ImportanceType = "HIGH"
+)
+
+func ImportanceTypeChoices() []string {
+	return []string{"LOW", "MEDIUM", "HIGH"}
 }
+
+type PluginOut struct {
+	Author      string     `json:"author"`
+	Class       string     `json:"class"`
+	DocUrl      string     `json:"docURL"`
+	Preview     *bool      `json:"preview,omitempty"`
+	PreviewInfo string     `json:"preview_info,omitempty"`
+	Title       string     `json:"title"`
+	Type        PluginType `json:"type"`
+	Version     string     `json:"version"`
+}
+type PluginType string
+
+const (
+	PluginTypeSink    PluginType = "sink"
+	PluginTypeSource  PluginType = "source"
+	PluginTypeUnknown PluginType = "unknown"
+)
+
+func PluginTypeChoices() []string {
+	return []string{"sink", "source", "unknown"}
+}
+
+type ServiceKafkaConnectConnectorStateType string
+
+const (
+	ServiceKafkaConnectConnectorStateTypeFailed     ServiceKafkaConnectConnectorStateType = "FAILED"
+	ServiceKafkaConnectConnectorStateTypePaused     ServiceKafkaConnectConnectorStateType = "PAUSED"
+	ServiceKafkaConnectConnectorStateTypeRunning    ServiceKafkaConnectConnectorStateType = "RUNNING"
+	ServiceKafkaConnectConnectorStateTypeUnassigned ServiceKafkaConnectConnectorStateType = "UNASSIGNED"
+)
+
+func ServiceKafkaConnectConnectorStateTypeChoices() []string {
+	return []string{"FAILED", "PAUSED", "RUNNING", "UNASSIGNED"}
+}
+
 type ServiceKafkaConnectCreateConnectorIn struct {
 	ConnectorClass string `json:"connector.class,omitempty"`
 	Name           string `json:"name"`
@@ -234,18 +289,44 @@ type ServiceKafkaConnectEditConnectorOut struct {
 	Tasks  []TaskOut `json:"tasks"`
 }
 type ServiceKafkaConnectGetConnectorStatusOut struct {
-	State string       `json:"state"`
-	Tasks []TaskOutAlt `json:"tasks"`
+	State ServiceKafkaConnectConnectorStateType `json:"state"`
+	Tasks []TaskOutAlt                          `json:"tasks"`
 }
 type TaskOut struct {
 	Connector string `json:"connector"`
 	Task      int    `json:"task"`
 }
 type TaskOutAlt struct {
-	Id    int    `json:"id"`
-	State string `json:"state"`
-	Trace string `json:"trace"`
+	Id    int           `json:"id"`
+	State TaskStateType `json:"state"`
+	Trace string        `json:"trace"`
 }
+type TaskStateType string
+
+const (
+	TaskStateTypeFailed     TaskStateType = "FAILED"
+	TaskStateTypePaused     TaskStateType = "PAUSED"
+	TaskStateTypeRunning    TaskStateType = "RUNNING"
+	TaskStateTypeUnassigned TaskStateType = "UNASSIGNED"
+)
+
+func TaskStateTypeChoices() []string {
+	return []string{"FAILED", "PAUSED", "RUNNING", "UNASSIGNED"}
+}
+
+type WidthType string
+
+const (
+	WidthTypeNone   WidthType = "NONE"
+	WidthTypeShort  WidthType = "SHORT"
+	WidthTypeMedium WidthType = "MEDIUM"
+	WidthTypeLong   WidthType = "LONG"
+)
+
+func WidthTypeChoices() []string {
+	return []string{"NONE", "SHORT", "MEDIUM", "LONG"}
+}
+
 type serviceKafkaConnectCreateConnectorOut struct {
 	Connector ServiceKafkaConnectCreateConnectorOut `json:"connector"`
 }

--- a/handler/kafkamirrormaker/kafkamirrormaker.go
+++ b/handler/kafkamirrormaker/kafkamirrormaker.go
@@ -109,19 +109,19 @@ func OffsetSyncsTopicLocationTypeChoices() []string {
 }
 
 type ReplicationFlowOut struct {
-	ConfigPropertiesExclude         string   `json:"config_properties_exclude,omitempty"`
-	EmitBackwardHeartbeatsEnabled   *bool    `json:"emit_backward_heartbeats_enabled,omitempty"`
-	EmitHeartbeatsEnabled           *bool    `json:"emit_heartbeats_enabled,omitempty"`
-	Enabled                         bool     `json:"enabled"`
-	OffsetLagMax                    *int     `json:"offset_lag_max,omitempty"`
-	OffsetSyncsTopicLocation        string   `json:"offset_syncs_topic_location,omitempty"`
-	ReplicationPolicyClass          string   `json:"replication_policy_class,omitempty"`
-	SourceCluster                   string   `json:"source_cluster"`
-	SyncGroupOffsetsEnabled         *bool    `json:"sync_group_offsets_enabled,omitempty"`
-	SyncGroupOffsetsIntervalSeconds *int     `json:"sync_group_offsets_interval_seconds,omitempty"`
-	TargetCluster                   string   `json:"target_cluster"`
-	Topics                          []string `json:"topics,omitempty"`
-	TopicsBlacklist                 string   `json:"topics.blacklist,omitempty"`
+	ConfigPropertiesExclude         string                       `json:"config_properties_exclude,omitempty"`
+	EmitBackwardHeartbeatsEnabled   *bool                        `json:"emit_backward_heartbeats_enabled,omitempty"`
+	EmitHeartbeatsEnabled           *bool                        `json:"emit_heartbeats_enabled,omitempty"`
+	Enabled                         bool                         `json:"enabled"`
+	OffsetLagMax                    *int                         `json:"offset_lag_max,omitempty"`
+	OffsetSyncsTopicLocation        OffsetSyncsTopicLocationType `json:"offset_syncs_topic_location,omitempty"`
+	ReplicationPolicyClass          ReplicationPolicyClassType   `json:"replication_policy_class,omitempty"`
+	SourceCluster                   string                       `json:"source_cluster"`
+	SyncGroupOffsetsEnabled         *bool                        `json:"sync_group_offsets_enabled,omitempty"`
+	SyncGroupOffsetsIntervalSeconds *int                         `json:"sync_group_offsets_interval_seconds,omitempty"`
+	TargetCluster                   string                       `json:"target_cluster"`
+	Topics                          []string                     `json:"topics,omitempty"`
+	TopicsBlacklist                 string                       `json:"topics.blacklist,omitempty"`
 }
 type ReplicationPolicyClassType string
 
@@ -150,19 +150,19 @@ type ServiceKafkaMirrorMakerCreateReplicationFlowIn struct {
 	TopicsBlacklist                 string                       `json:"topics.blacklist,omitempty"`
 }
 type ServiceKafkaMirrorMakerGetReplicationFlowOut struct {
-	ConfigPropertiesExclude         string   `json:"config_properties_exclude,omitempty"`
-	EmitBackwardHeartbeatsEnabled   *bool    `json:"emit_backward_heartbeats_enabled,omitempty"`
-	EmitHeartbeatsEnabled           *bool    `json:"emit_heartbeats_enabled,omitempty"`
-	Enabled                         bool     `json:"enabled"`
-	OffsetLagMax                    *int     `json:"offset_lag_max,omitempty"`
-	OffsetSyncsTopicLocation        string   `json:"offset_syncs_topic_location,omitempty"`
-	ReplicationPolicyClass          string   `json:"replication_policy_class,omitempty"`
-	SourceCluster                   string   `json:"source_cluster"`
-	SyncGroupOffsetsEnabled         *bool    `json:"sync_group_offsets_enabled,omitempty"`
-	SyncGroupOffsetsIntervalSeconds *int     `json:"sync_group_offsets_interval_seconds,omitempty"`
-	TargetCluster                   string   `json:"target_cluster"`
-	Topics                          []string `json:"topics,omitempty"`
-	TopicsBlacklist                 string   `json:"topics.blacklist,omitempty"`
+	ConfigPropertiesExclude         string                       `json:"config_properties_exclude,omitempty"`
+	EmitBackwardHeartbeatsEnabled   *bool                        `json:"emit_backward_heartbeats_enabled,omitempty"`
+	EmitHeartbeatsEnabled           *bool                        `json:"emit_heartbeats_enabled,omitempty"`
+	Enabled                         bool                         `json:"enabled"`
+	OffsetLagMax                    *int                         `json:"offset_lag_max,omitempty"`
+	OffsetSyncsTopicLocation        OffsetSyncsTopicLocationType `json:"offset_syncs_topic_location,omitempty"`
+	ReplicationPolicyClass          ReplicationPolicyClassType   `json:"replication_policy_class,omitempty"`
+	SourceCluster                   string                       `json:"source_cluster"`
+	SyncGroupOffsetsEnabled         *bool                        `json:"sync_group_offsets_enabled,omitempty"`
+	SyncGroupOffsetsIntervalSeconds *int                         `json:"sync_group_offsets_interval_seconds,omitempty"`
+	TargetCluster                   string                       `json:"target_cluster"`
+	Topics                          []string                     `json:"topics,omitempty"`
+	TopicsBlacklist                 string                       `json:"topics.blacklist,omitempty"`
 }
 type ServiceKafkaMirrorMakerPatchReplicationFlowIn struct {
 	ConfigPropertiesExclude         string                       `json:"config_properties_exclude,omitempty"`
@@ -178,19 +178,19 @@ type ServiceKafkaMirrorMakerPatchReplicationFlowIn struct {
 	TopicsBlacklist                 string                       `json:"topics.blacklist,omitempty"`
 }
 type ServiceKafkaMirrorMakerPatchReplicationFlowOut struct {
-	ConfigPropertiesExclude         string   `json:"config_properties_exclude,omitempty"`
-	EmitBackwardHeartbeatsEnabled   *bool    `json:"emit_backward_heartbeats_enabled,omitempty"`
-	EmitHeartbeatsEnabled           *bool    `json:"emit_heartbeats_enabled,omitempty"`
-	Enabled                         bool     `json:"enabled"`
-	OffsetLagMax                    *int     `json:"offset_lag_max,omitempty"`
-	OffsetSyncsTopicLocation        string   `json:"offset_syncs_topic_location,omitempty"`
-	ReplicationPolicyClass          string   `json:"replication_policy_class,omitempty"`
-	SourceCluster                   string   `json:"source_cluster"`
-	SyncGroupOffsetsEnabled         *bool    `json:"sync_group_offsets_enabled,omitempty"`
-	SyncGroupOffsetsIntervalSeconds *int     `json:"sync_group_offsets_interval_seconds,omitempty"`
-	TargetCluster                   string   `json:"target_cluster"`
-	Topics                          []string `json:"topics,omitempty"`
-	TopicsBlacklist                 string   `json:"topics.blacklist,omitempty"`
+	ConfigPropertiesExclude         string                       `json:"config_properties_exclude,omitempty"`
+	EmitBackwardHeartbeatsEnabled   *bool                        `json:"emit_backward_heartbeats_enabled,omitempty"`
+	EmitHeartbeatsEnabled           *bool                        `json:"emit_heartbeats_enabled,omitempty"`
+	Enabled                         bool                         `json:"enabled"`
+	OffsetLagMax                    *int                         `json:"offset_lag_max,omitempty"`
+	OffsetSyncsTopicLocation        OffsetSyncsTopicLocationType `json:"offset_syncs_topic_location,omitempty"`
+	ReplicationPolicyClass          ReplicationPolicyClassType   `json:"replication_policy_class,omitempty"`
+	SourceCluster                   string                       `json:"source_cluster"`
+	SyncGroupOffsetsEnabled         *bool                        `json:"sync_group_offsets_enabled,omitempty"`
+	SyncGroupOffsetsIntervalSeconds *int                         `json:"sync_group_offsets_interval_seconds,omitempty"`
+	TargetCluster                   string                       `json:"target_cluster"`
+	Topics                          []string                     `json:"topics,omitempty"`
+	TopicsBlacklist                 string                       `json:"topics.blacklist,omitempty"`
 }
 type serviceKafkaMirrorMakerGetReplicationFlowOut struct {
 	ReplicationFlow ServiceKafkaMirrorMakerGetReplicationFlowOut `json:"replication_flow"`

--- a/handler/kafkaschemaregistry/kafkaschemaregistry.go
+++ b/handler/kafkaschemaregistry/kafkaschemaregistry.go
@@ -25,19 +25,19 @@ type Handler interface {
 	ServiceSchemaRegistryAclList(ctx context.Context, project string, serviceName string) ([]AclOut, error)
 
 	// ServiceSchemaRegistryCompatibility check compatibility of schema in Schema Registry
-	// POST /project/{project}/service/{service_name}/kafka/schema/compatibility/subjects/{subject_name}/versions/{version_id:latest|\d+}
+	// POST /project/{project}/service/{service_name}/kafka/schema/compatibility/subjects/{subject_name}/versions/{version_id}
 	// https://api.aiven.io/doc/#tag/Service:_Kafka/operation/ServiceSchemaRegistryCompatibility
 	ServiceSchemaRegistryCompatibility(ctx context.Context, project string, serviceName string, subjectName string, versionId int, in *ServiceSchemaRegistryCompatibilityIn) (bool, error)
 
 	// ServiceSchemaRegistryGlobalConfigGet get global configuration for Schema Registry
 	// GET /project/{project}/service/{service_name}/kafka/schema/config
 	// https://api.aiven.io/doc/#tag/Service:_Kafka/operation/ServiceSchemaRegistryGlobalConfigGet
-	ServiceSchemaRegistryGlobalConfigGet(ctx context.Context, project string, serviceName string) (string, error)
+	ServiceSchemaRegistryGlobalConfigGet(ctx context.Context, project string, serviceName string) (CompatibilityType, error)
 
 	// ServiceSchemaRegistryGlobalConfigPut edit global configuration for Schema Registry
 	// PUT /project/{project}/service/{service_name}/kafka/schema/config
 	// https://api.aiven.io/doc/#tag/Service:_Kafka/operation/ServiceSchemaRegistryGlobalConfigPut
-	ServiceSchemaRegistryGlobalConfigPut(ctx context.Context, project string, serviceName string, in *ServiceSchemaRegistryGlobalConfigPutIn) (string, error)
+	ServiceSchemaRegistryGlobalConfigPut(ctx context.Context, project string, serviceName string, in *ServiceSchemaRegistryGlobalConfigPutIn) (CompatibilityType, error)
 
 	// ServiceSchemaRegistrySchemaGet get schema in Schema Registry
 	// GET /project/{project}/service/{service_name}/kafka/schema/schemas/ids/{schema_id}
@@ -47,12 +47,12 @@ type Handler interface {
 	// ServiceSchemaRegistrySubjectConfigGet get configuration for Schema Registry subject
 	// GET /project/{project}/service/{service_name}/kafka/schema/config/{subject_name}
 	// https://api.aiven.io/doc/#tag/Service:_Kafka/operation/ServiceSchemaRegistrySubjectConfigGet
-	ServiceSchemaRegistrySubjectConfigGet(ctx context.Context, project string, serviceName string, subjectName string) (string, error)
+	ServiceSchemaRegistrySubjectConfigGet(ctx context.Context, project string, serviceName string, subjectName string) (CompatibilityType, error)
 
 	// ServiceSchemaRegistrySubjectConfigPut edit configuration for Schema Registry subject
 	// PUT /project/{project}/service/{service_name}/kafka/schema/config/{subject_name}
 	// https://api.aiven.io/doc/#tag/Service:_Kafka/operation/ServiceSchemaRegistrySubjectConfigPut
-	ServiceSchemaRegistrySubjectConfigPut(ctx context.Context, project string, serviceName string, subjectName string, in *ServiceSchemaRegistrySubjectConfigPutIn) (string, error)
+	ServiceSchemaRegistrySubjectConfigPut(ctx context.Context, project string, serviceName string, subjectName string, in *ServiceSchemaRegistrySubjectConfigPutIn) (CompatibilityType, error)
 
 	// ServiceSchemaRegistrySubjectDelete delete Schema Registry subject
 	// DELETE /project/{project}/service/{service_name}/kafka/schema/subjects/{subject_name}
@@ -60,12 +60,12 @@ type Handler interface {
 	ServiceSchemaRegistrySubjectDelete(ctx context.Context, project string, serviceName string, subjectName string) error
 
 	// ServiceSchemaRegistrySubjectVersionDelete delete Schema Registry subject version
-	// DELETE /project/{project}/service/{service_name}/kafka/schema/subjects/{subject_name}/versions/{version_id:latest|\d+}
+	// DELETE /project/{project}/service/{service_name}/kafka/schema/subjects/{subject_name}/versions/{version_id}
 	// https://api.aiven.io/doc/#tag/Service:_Kafka/operation/ServiceSchemaRegistrySubjectVersionDelete
 	ServiceSchemaRegistrySubjectVersionDelete(ctx context.Context, project string, serviceName string, subjectName string, versionId int) error
 
 	// ServiceSchemaRegistrySubjectVersionGet get Schema Registry Subject version
-	// GET /project/{project}/service/{service_name}/kafka/schema/subjects/{subject_name}/versions/{version_id:latest|\d+}
+	// GET /project/{project}/service/{service_name}/kafka/schema/subjects/{subject_name}/versions/{version_id}
 	// https://api.aiven.io/doc/#tag/Service:_Kafka/operation/ServiceSchemaRegistrySubjectVersionGet
 	ServiceSchemaRegistrySubjectVersionGet(ctx context.Context, project string, serviceName string, subjectName string, versionId int) error
 
@@ -149,7 +149,7 @@ func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistryCompatibility(ctx cont
 	}
 	return out.IsCompatible, nil
 }
-func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistryGlobalConfigGet(ctx context.Context, project string, serviceName string) (string, error) {
+func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistryGlobalConfigGet(ctx context.Context, project string, serviceName string) (CompatibilityType, error) {
 	path := fmt.Sprintf("/project/%s/service/%s/kafka/schema/config", project, serviceName)
 	b, err := h.doer.Do(ctx, "ServiceSchemaRegistryGlobalConfigGet", "GET", path, nil)
 	if err != nil {
@@ -162,7 +162,7 @@ func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistryGlobalConfigGet(ctx co
 	}
 	return out.CompatibilityLevel, nil
 }
-func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistryGlobalConfigPut(ctx context.Context, project string, serviceName string, in *ServiceSchemaRegistryGlobalConfigPutIn) (string, error) {
+func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistryGlobalConfigPut(ctx context.Context, project string, serviceName string, in *ServiceSchemaRegistryGlobalConfigPutIn) (CompatibilityType, error) {
 	path := fmt.Sprintf("/project/%s/service/%s/kafka/schema/config", project, serviceName)
 	b, err := h.doer.Do(ctx, "ServiceSchemaRegistryGlobalConfigPut", "PUT", path, in)
 	if err != nil {
@@ -180,7 +180,7 @@ func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistrySchemaGet(ctx context.
 	_, err := h.doer.Do(ctx, "ServiceSchemaRegistrySchemaGet", "GET", path, nil)
 	return err
 }
-func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistrySubjectConfigGet(ctx context.Context, project string, serviceName string, subjectName string) (string, error) {
+func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistrySubjectConfigGet(ctx context.Context, project string, serviceName string, subjectName string) (CompatibilityType, error) {
 	path := fmt.Sprintf("/project/%s/service/%s/kafka/schema/config/%s", project, serviceName, subjectName)
 	b, err := h.doer.Do(ctx, "ServiceSchemaRegistrySubjectConfigGet", "GET", path, nil)
 	if err != nil {
@@ -193,7 +193,7 @@ func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistrySubjectConfigGet(ctx c
 	}
 	return out.CompatibilityLevel, nil
 }
-func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistrySubjectConfigPut(ctx context.Context, project string, serviceName string, subjectName string, in *ServiceSchemaRegistrySubjectConfigPutIn) (string, error) {
+func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistrySubjectConfigPut(ctx context.Context, project string, serviceName string, subjectName string, in *ServiceSchemaRegistrySubjectConfigPutIn) (CompatibilityType, error) {
 	path := fmt.Sprintf("/project/%s/service/%s/kafka/schema/config/%s", project, serviceName, subjectName)
 	b, err := h.doer.Do(ctx, "ServiceSchemaRegistrySubjectConfigPut", "PUT", path, in)
 	if err != nil {
@@ -262,10 +262,10 @@ func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistrySubjects(ctx context.C
 }
 
 type AclOut struct {
-	Id         string `json:"id,omitempty"`
-	Permission string `json:"permission"`
-	Resource   string `json:"resource"`
-	Username   string `json:"username"`
+	Id         string         `json:"id,omitempty"`
+	Permission PermissionType `json:"permission"`
+	Resource   string         `json:"resource"`
+	Username   string         `json:"username"`
 }
 type CompatibilityType string
 
@@ -344,16 +344,16 @@ type serviceSchemaRegistryCompatibilityOut struct {
 	IsCompatible bool `json:"is_compatible"`
 }
 type serviceSchemaRegistryGlobalConfigGetOut struct {
-	CompatibilityLevel string `json:"compatibilityLevel"`
+	CompatibilityLevel CompatibilityType `json:"compatibilityLevel"`
 }
 type serviceSchemaRegistryGlobalConfigPutOut struct {
-	Compatibility string `json:"compatibility"`
+	Compatibility CompatibilityType `json:"compatibility"`
 }
 type serviceSchemaRegistrySubjectConfigGetOut struct {
-	CompatibilityLevel string `json:"compatibilityLevel"`
+	CompatibilityLevel CompatibilityType `json:"compatibilityLevel"`
 }
 type serviceSchemaRegistrySubjectConfigPutOut struct {
-	Compatibility string `json:"compatibility"`
+	Compatibility CompatibilityType `json:"compatibility"`
 }
 type serviceSchemaRegistrySubjectVersionPostOut struct {
 	Id int `json:"id"`

--- a/handler/kafkatopic/kafkatopic.go
+++ b/handler/kafkatopic/kafkatopic.go
@@ -126,7 +126,7 @@ func (h *KafkaTopicHandler) ServiceKafkaTopicUpdate(ctx context.Context, project
 }
 
 type CleanupPolicyOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    string       `json:"value,omitempty"`
 }
@@ -158,10 +158,25 @@ func CompressionTypeChoices() []string {
 }
 
 type CompressionTypeOut struct {
-	Source   string       `json:"source,omitempty"`
-	Synonyms []SynonymOut `json:"synonyms,omitempty"`
-	Value    string       `json:"value,omitempty"`
+	Source   SourceType           `json:"source,omitempty"`
+	Synonyms []SynonymOut         `json:"synonyms,omitempty"`
+	Value    CompressionTypeValue `json:"value,omitempty"`
 }
+type CompressionTypeValue string
+
+const (
+	CompressionTypeValueSnappy       CompressionTypeValue = "snappy"
+	CompressionTypeValueGzip         CompressionTypeValue = "gzip"
+	CompressionTypeValueLz4          CompressionTypeValue = "lz4"
+	CompressionTypeValueProducer     CompressionTypeValue = "producer"
+	CompressionTypeValueUncompressed CompressionTypeValue = "uncompressed"
+	CompressionTypeValueZstd         CompressionTypeValue = "zstd"
+)
+
+func CompressionTypeValueChoices() []string {
+	return []string{"snappy", "gzip", "lz4", "producer", "uncompressed", "zstd"}
+}
+
 type ConfigIn struct {
 	CleanupPolicy                   CleanupPolicyType        `json:"cleanup_policy,omitempty"`
 	CompressionType                 CompressionType          `json:"compression_type,omitempty"`
@@ -225,22 +240,22 @@ type ConsumerGroupOut struct {
 	Offset    int    `json:"offset"`
 }
 type DeleteRetentionMsOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
 type FileDeleteDelayMsOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
 type FlushMessagesOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
 type FlushMsOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
@@ -259,39 +274,39 @@ func FormatTypeChoices() []string {
 }
 
 type IndexIntervalBytesOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
 type LocalRetentionBytesOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
 type LocalRetentionMsOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
 type MaxCompactionLagMsOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
 type MaxMessageBytesOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
 type MessageDownconversionEnableOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *bool        `json:"value,omitempty"`
 }
 type MessageFormatVersionOut struct {
-	Source   string       `json:"source,omitempty"`
-	Synonyms []SynonymOut `json:"synonyms,omitempty"`
-	Value    string       `json:"value,omitempty"`
+	Source   SourceType               `json:"source,omitempty"`
+	Synonyms []SynonymOut             `json:"synonyms,omitempty"`
+	Value    MessageFormatVersionType `json:"value,omitempty"`
 }
 type MessageFormatVersionType string
 
@@ -380,7 +395,7 @@ type MessageOut struct {
 	Value     map[string]any `json:"value,omitempty"`
 }
 type MessageTimestampDifferenceMaxMsOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
@@ -396,22 +411,33 @@ func MessageTimestampTypeChoices() []string {
 }
 
 type MessageTimestampTypeOut struct {
-	Source   string       `json:"source,omitempty"`
-	Synonyms []SynonymOut `json:"synonyms,omitempty"`
-	Value    string       `json:"value,omitempty"`
+	Source   SourceType                `json:"source,omitempty"`
+	Synonyms []SynonymOut              `json:"synonyms,omitempty"`
+	Value    MessageTimestampTypeValue `json:"value,omitempty"`
 }
+type MessageTimestampTypeValue string
+
+const (
+	MessageTimestampTypeValueCreateTime    MessageTimestampTypeValue = "CreateTime"
+	MessageTimestampTypeValueLogAppendTime MessageTimestampTypeValue = "LogAppendTime"
+)
+
+func MessageTimestampTypeValueChoices() []string {
+	return []string{"CreateTime", "LogAppendTime"}
+}
+
 type MinCleanableDirtyRatioOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *float64     `json:"value,omitempty"`
 }
 type MinCompactionLagMsOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
 type MinInsyncReplicasOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
@@ -427,10 +453,11 @@ type PartitionOut struct {
 	Isr            int                `json:"isr"`
 	LatestOffset   int                `json:"latest_offset"`
 	Partition      int                `json:"partition"`
+	RemoteSize     *int               `json:"remote_size,omitempty"`
 	Size           int                `json:"size"`
 }
 type PreallocateOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *bool        `json:"value,omitempty"`
 }
@@ -440,37 +467,37 @@ type RecordIn struct {
 	Value     *map[string]any `json:"value,omitempty"`
 }
 type RemoteStorageEnableOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *bool        `json:"value,omitempty"`
 }
 type RetentionBytesOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
 type RetentionMsOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
 type SegmentBytesOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
 type SegmentIndexBytesOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
 type SegmentJitterMsOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
 type SegmentMsOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *int         `json:"value,omitempty"`
 }
@@ -493,7 +520,7 @@ type ServiceKafkaTopicGetOut struct {
 	Replication       int            `json:"replication"`
 	RetentionBytes    int            `json:"retention_bytes"`
 	RetentionHours    int            `json:"retention_hours"`
-	State             string         `json:"state"`
+	State             TopicStateType `json:"state"`
 	Tags              []TagOut       `json:"tags"`
 	TopicName         string         `json:"topic_name"`
 }
@@ -525,10 +552,26 @@ type ServiceKafkaTopicUpdateIn struct {
 	RetentionHours    *int      `json:"retention_hours,omitempty"`
 	Tags              *[]TagIn  `json:"tags,omitempty"`
 }
+type SourceType string
+
+const (
+	SourceTypeUnknownConfig              SourceType = "unknown_config"
+	SourceTypeTopicConfig                SourceType = "topic_config"
+	SourceTypeDynamicBrokerConfig        SourceType = "dynamic_broker_config"
+	SourceTypeDynamicDefaultBrokerConfig SourceType = "dynamic_default_broker_config"
+	SourceTypeStaticBrokerConfig         SourceType = "static_broker_config"
+	SourceTypeDefaultConfig              SourceType = "default_config"
+	SourceTypeDynamicBrokerLoggerConfig  SourceType = "dynamic_broker_logger_config"
+)
+
+func SourceTypeChoices() []string {
+	return []string{"unknown_config", "topic_config", "dynamic_broker_config", "dynamic_default_broker_config", "static_broker_config", "default_config", "dynamic_broker_logger_config"}
+}
+
 type SynonymOut struct {
-	Name   string `json:"name,omitempty"`
-	Source string `json:"source,omitempty"`
-	Value  *bool  `json:"value,omitempty"`
+	Name   string     `json:"name,omitempty"`
+	Source SourceType `json:"source,omitempty"`
+	Value  *bool      `json:"value,omitempty"`
 }
 type TagIn struct {
 	Key   string `json:"key"`
@@ -539,19 +582,31 @@ type TagOut struct {
 	Value string `json:"value"`
 }
 type TopicOut struct {
-	CleanupPolicy       string   `json:"cleanup_policy"`
-	MinInsyncReplicas   int      `json:"min_insync_replicas"`
-	Partitions          int      `json:"partitions"`
-	RemoteStorageEnable *bool    `json:"remote_storage_enable,omitempty"`
-	Replication         int      `json:"replication"`
-	RetentionBytes      int      `json:"retention_bytes"`
-	RetentionHours      int      `json:"retention_hours"`
-	State               string   `json:"state"`
-	Tags                []TagOut `json:"tags"`
-	TopicName           string   `json:"topic_name"`
+	CleanupPolicy       string         `json:"cleanup_policy"`
+	MinInsyncReplicas   int            `json:"min_insync_replicas"`
+	Partitions          int            `json:"partitions"`
+	RemoteStorageEnable *bool          `json:"remote_storage_enable,omitempty"`
+	Replication         int            `json:"replication"`
+	RetentionBytes      int            `json:"retention_bytes"`
+	RetentionHours      int            `json:"retention_hours"`
+	State               TopicStateType `json:"state"`
+	Tags                []TagOut       `json:"tags"`
+	TopicName           string         `json:"topic_name"`
 }
+type TopicStateType string
+
+const (
+	TopicStateTypeActive      TopicStateType = "ACTIVE"
+	TopicStateTypeConfiguring TopicStateType = "CONFIGURING"
+	TopicStateTypeDeleting    TopicStateType = "DELETING"
+)
+
+func TopicStateTypeChoices() []string {
+	return []string{"ACTIVE", "CONFIGURING", "DELETING"}
+}
+
 type UncleanLeaderElectionEnableOut struct {
-	Source   string       `json:"source,omitempty"`
+	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
 	Value    *bool        `json:"value,omitempty"`
 }

--- a/handler/opensearch/opensearch.go
+++ b/handler/opensearch/opensearch.go
@@ -35,7 +35,7 @@ type Handler interface {
 	// https://api.aiven.io/doc/#tag/Service:_OpenSearch/operation/ServiceOpenSearchIndexList
 	ServiceOpenSearchIndexList(ctx context.Context, project string, serviceName string) ([]IndexeOut, error)
 
-	// ServiceOpenSearchSecurityGet show Opensearch security configuration status
+	// ServiceOpenSearchSecurityGet show OpenSearch security configuration status
 	// GET /project/{project}/service/{service_name}/opensearch/security
 	// https://api.aiven.io/doc/#tag/Service:_OpenSearch/operation/ServiceOpenSearchSecurityGet
 	ServiceOpenSearchSecurityGet(ctx context.Context, project string, serviceName string) (*ServiceOpenSearchSecurityGetOut, error)
@@ -168,18 +168,45 @@ type AclOut struct {
 	Rules    []RuleOut `json:"rules"`
 	Username string    `json:"username"`
 }
-type IndexeOut struct {
-	CreateTime          time.Time       `json:"create_time"`
-	Docs                *int            `json:"docs,omitempty"`
-	Health              string          `json:"health,omitempty"`
-	IndexName           string          `json:"index_name"`
-	NumberOfReplicas    int             `json:"number_of_replicas"`
-	NumberOfShards      int             `json:"number_of_shards"`
-	ReadOnlyAllowDelete *bool           `json:"read_only_allow_delete,omitempty"`
-	Replication         *ReplicationOut `json:"replication,omitempty"`
-	Size                *int            `json:"size,omitempty"`
-	Status              string          `json:"status,omitempty"`
+type HealthType string
+
+const (
+	HealthTypeGreen       HealthType = "green"
+	HealthTypeYellow      HealthType = "yellow"
+	HealthTypeRed         HealthType = "red"
+	HealthTypeRedAsterisk HealthType = "red*"
+	HealthTypeUnknown     HealthType = "unknown"
+)
+
+func HealthTypeChoices() []string {
+	return []string{"green", "yellow", "red", "red*", "unknown"}
 }
+
+type IndexeOut struct {
+	CreateTime          time.Time        `json:"create_time"`
+	Docs                *int             `json:"docs,omitempty"`
+	Health              HealthType       `json:"health,omitempty"`
+	IndexName           string           `json:"index_name"`
+	NumberOfReplicas    int              `json:"number_of_replicas"`
+	NumberOfShards      int              `json:"number_of_shards"`
+	ReadOnlyAllowDelete *bool            `json:"read_only_allow_delete,omitempty"`
+	Replication         *ReplicationOut  `json:"replication,omitempty"`
+	Size                *int             `json:"size,omitempty"`
+	Status              IndexeStatusType `json:"status,omitempty"`
+}
+type IndexeStatusType string
+
+const (
+	IndexeStatusTypeUnknown IndexeStatusType = "unknown"
+	IndexeStatusTypeOpen    IndexeStatusType = "open"
+	IndexeStatusTypeClose   IndexeStatusType = "close"
+	IndexeStatusTypeNone    IndexeStatusType = "none"
+)
+
+func IndexeStatusTypeChoices() []string {
+	return []string{"unknown", "open", "close", "none"}
+}
+
 type OpensearchAclConfigIn struct {
 	Acls    []AclIn `json:"acls"`
 	Enabled bool    `json:"enabled"`
@@ -212,8 +239,8 @@ type RuleIn struct {
 	Permission PermissionType `json:"permission"`
 }
 type RuleOut struct {
-	Index      string `json:"index"`
-	Permission string `json:"permission"`
+	Index      string         `json:"index"`
+	Permission PermissionType `json:"permission"`
 }
 type ServiceOpenSearchAclGetOut struct {
 	Acls    []AclOut `json:"acls"`

--- a/handler/organization/organization.go
+++ b/handler/organization/organization.go
@@ -150,6 +150,27 @@ func (h *OrganizationHandler) UserOrganizationsList(ctx context.Context) ([]Orga
 	return out.Organizations, nil
 }
 
+type BillingCurrencyType string
+
+const (
+	BillingCurrencyTypeAud BillingCurrencyType = "AUD"
+	BillingCurrencyTypeCad BillingCurrencyType = "CAD"
+	BillingCurrencyTypeChf BillingCurrencyType = "CHF"
+	BillingCurrencyTypeDkk BillingCurrencyType = "DKK"
+	BillingCurrencyTypeEur BillingCurrencyType = "EUR"
+	BillingCurrencyTypeGbp BillingCurrencyType = "GBP"
+	BillingCurrencyTypeJpy BillingCurrencyType = "JPY"
+	BillingCurrencyTypeNok BillingCurrencyType = "NOK"
+	BillingCurrencyTypeNzd BillingCurrencyType = "NZD"
+	BillingCurrencyTypeSek BillingCurrencyType = "SEK"
+	BillingCurrencyTypeSgd BillingCurrencyType = "SGD"
+	BillingCurrencyTypeUsd BillingCurrencyType = "USD"
+)
+
+func BillingCurrencyTypeChoices() []string {
+	return []string{"AUD", "CAD", "CHF", "DKK", "EUR", "GBP", "JPY", "NOK", "NZD", "SEK", "SGD", "USD"}
+}
+
 type BillingEmailOut struct {
 	Email string `json:"email"`
 }
@@ -190,36 +211,41 @@ type OrganizationAuthenticationConfigUpdateOut struct {
 	TwoFactorRequired   *bool `json:"two_factor_required,omitempty"`
 }
 type OrganizationGetOut struct {
-	AccountId        string    `json:"account_id"`
-	CreateTime       time.Time `json:"create_time"`
-	OrganizationId   string    `json:"organization_id"`
-	OrganizationName string    `json:"organization_name"`
-	Tier             string    `json:"tier"`
-	UpdateTime       time.Time `json:"update_time"`
+	AccountId                    string    `json:"account_id"`
+	CreateTime                   time.Time `json:"create_time"`
+	DefaultGovernanceUserGroupId string    `json:"default_governance_user_group_id,omitempty"`
+	OrganizationId               string    `json:"organization_id"`
+	OrganizationName             string    `json:"organization_name"`
+	Tier                         TierType  `json:"tier"`
+	UpdateTime                   time.Time `json:"update_time"`
 }
 type OrganizationOut struct {
-	AccountId        string    `json:"account_id"`
-	CreateTime       time.Time `json:"create_time"`
-	OrganizationId   string    `json:"organization_id"`
-	OrganizationName string    `json:"organization_name"`
-	Tier             string    `json:"tier"`
-	UpdateTime       time.Time `json:"update_time"`
+	AccountId                    string    `json:"account_id"`
+	CreateTime                   time.Time `json:"create_time"`
+	DefaultGovernanceUserGroupId string    `json:"default_governance_user_group_id,omitempty"`
+	OrganizationId               string    `json:"organization_id"`
+	OrganizationName             string    `json:"organization_name"`
+	Tier                         TierType  `json:"tier"`
+	UpdateTime                   time.Time `json:"update_time"`
 }
 type OrganizationProjectsListOut struct {
 	Projects          []ProjectOut `json:"projects"`
 	TotalProjectCount *int         `json:"total_project_count,omitempty"`
 }
 type OrganizationUpdateIn struct {
-	Name string   `json:"name,omitempty"`
-	Tier TierType `json:"tier,omitempty"`
+	DefaultGovernanceUserGroupId string   `json:"default_governance_user_group_id,omitempty"`
+	KafkaGovernanceEnabled       *bool    `json:"kafka_governance_enabled,omitempty"`
+	Name                         string   `json:"name,omitempty"`
+	Tier                         TierType `json:"tier,omitempty"`
 }
 type OrganizationUpdateOut struct {
-	AccountId        string    `json:"account_id"`
-	CreateTime       time.Time `json:"create_time"`
-	OrganizationId   string    `json:"organization_id"`
-	OrganizationName string    `json:"organization_name"`
-	Tier             string    `json:"tier"`
-	UpdateTime       time.Time `json:"update_time"`
+	AccountId                    string    `json:"account_id"`
+	CreateTime                   time.Time `json:"create_time"`
+	DefaultGovernanceUserGroupId string    `json:"default_governance_user_group_id,omitempty"`
+	OrganizationId               string    `json:"organization_id"`
+	OrganizationName             string    `json:"organization_name"`
+	Tier                         TierType  `json:"tier"`
+	UpdateTime                   time.Time `json:"update_time"`
 }
 type ProjectOut struct {
 	AccountId             string                 `json:"account_id"`
@@ -227,7 +253,7 @@ type ProjectOut struct {
 	AddressLines          []string               `json:"address_lines,omitempty"`
 	AvailableCredits      string                 `json:"available_credits,omitempty"`
 	BillingAddress        string                 `json:"billing_address"`
-	BillingCurrency       string                 `json:"billing_currency,omitempty"`
+	BillingCurrency       BillingCurrencyType    `json:"billing_currency,omitempty"`
 	BillingEmails         []BillingEmailOut      `json:"billing_emails"`
 	BillingExtraText      string                 `json:"billing_extra_text,omitempty"`
 	BillingGroupId        string                 `json:"billing_group_id"`
@@ -273,12 +299,13 @@ type UserOrganizationCreateIn struct {
 	Tier                  TierType `json:"tier"`
 }
 type UserOrganizationCreateOut struct {
-	AccountId        string    `json:"account_id"`
-	CreateTime       time.Time `json:"create_time"`
-	OrganizationId   string    `json:"organization_id"`
-	OrganizationName string    `json:"organization_name"`
-	Tier             string    `json:"tier"`
-	UpdateTime       time.Time `json:"update_time"`
+	AccountId                    string    `json:"account_id"`
+	CreateTime                   time.Time `json:"create_time"`
+	DefaultGovernanceUserGroupId string    `json:"default_governance_user_group_id,omitempty"`
+	OrganizationId               string    `json:"organization_id"`
+	OrganizationName             string    `json:"organization_name"`
+	Tier                         TierType  `json:"tier"`
+	UpdateTime                   time.Time `json:"update_time"`
 }
 type userOrganizationsListOut struct {
 	Organizations []OrganizationOut `json:"organizations"`

--- a/handler/organizationuser/organizationuser.go
+++ b/handler/organizationuser/organizationuser.go
@@ -60,11 +60,6 @@ type Handler interface {
 	// https://api.aiven.io/doc/#tag/Users/operation/OrganizationUserRevokeToken
 	OrganizationUserRevokeToken(ctx context.Context, organizationId string, memberUserId string, tokenPrefix string) error
 
-	// OrganizationUserSet add or modify a user of the organization
-	// PUT /organization/{organization_id}/user/{member_user_id}
-	// https://api.aiven.io/doc/#tag/Users/operation/OrganizationUserSet
-	OrganizationUserSet(ctx context.Context, organizationId string, memberUserId string) (*OrganizationUserSetOut, error)
-
 	// OrganizationUserTokensList list tokens from an organization's member
 	// GET /organization/{organization_id}/user/{member_user_id}/access-tokens
 	// https://api.aiven.io/doc/#tag/Users/operation/OrganizationUserTokensList
@@ -170,19 +165,6 @@ func (h *OrganizationUserHandler) OrganizationUserRevokeToken(ctx context.Contex
 	_, err := h.doer.Do(ctx, "OrganizationUserRevokeToken", "DELETE", path, nil)
 	return err
 }
-func (h *OrganizationUserHandler) OrganizationUserSet(ctx context.Context, organizationId string, memberUserId string) (*OrganizationUserSetOut, error) {
-	path := fmt.Sprintf("/organization/%s/user/%s", organizationId, memberUserId)
-	b, err := h.doer.Do(ctx, "OrganizationUserSet", "PUT", path, nil)
-	if err != nil {
-		return nil, err
-	}
-	out := new(OrganizationUserSetOut)
-	err = json.Unmarshal(b, out)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
 func (h *OrganizationUserHandler) OrganizationUserTokensList(ctx context.Context, organizationId string, memberUserId string) ([]TokenOut, error) {
 	path := fmt.Sprintf("/organization/%s/user/%s/access-tokens", organizationId, memberUserId)
 	b, err := h.doer.Do(ctx, "OrganizationUserTokensList", "GET", path, nil)
@@ -251,21 +233,26 @@ type OrganizationUserInvitationAcceptIn struct {
 type OrganizationUserInviteIn struct {
 	UserEmail string `json:"user_email"`
 }
-type OrganizationUserSetOut struct {
-	IsSuperAdmin     bool        `json:"is_super_admin"`
-	JoinTime         time.Time   `json:"join_time"`
-	LastActivityTime time.Time   `json:"last_activity_time"`
-	UserId           string      `json:"user_id"`
-	UserInfo         UserInfoOut `json:"user_info"`
+type OrganizationUserStateType string
+
+const (
+	OrganizationUserStateTypeActive      OrganizationUserStateType = "active"
+	OrganizationUserStateTypeDeactivated OrganizationUserStateType = "deactivated"
+	OrganizationUserStateTypeDeleted     OrganizationUserStateType = "deleted"
+)
+
+func OrganizationUserStateTypeChoices() []string {
+	return []string{"active", "deactivated", "deleted"}
 }
+
 type OrganizationUserUpdateIn struct {
-	City         string    `json:"city,omitempty"`
-	Country      string    `json:"country,omitempty"`
-	Department   string    `json:"department,omitempty"`
-	IsSuperAdmin *bool     `json:"is_super_admin,omitempty"`
-	JobTitle     string    `json:"job_title,omitempty"`
-	RealName     string    `json:"real_name,omitempty"`
-	State        StateType `json:"state,omitempty"`
+	City         string                    `json:"city,omitempty"`
+	Country      string                    `json:"country,omitempty"`
+	Department   string                    `json:"department,omitempty"`
+	IsSuperAdmin *bool                     `json:"is_super_admin,omitempty"`
+	JobTitle     string                    `json:"job_title,omitempty"`
+	RealName     string                    `json:"real_name,omitempty"`
+	State        OrganizationUserStateType `json:"state,omitempty"`
 }
 type OrganizationUserUpdateOut struct {
 	IsSuperAdmin     bool        `json:"is_super_admin"`
@@ -274,18 +261,6 @@ type OrganizationUserUpdateOut struct {
 	UserId           string      `json:"user_id"`
 	UserInfo         UserInfoOut `json:"user_info"`
 }
-type StateType string
-
-const (
-	StateTypeActive      StateType = "active"
-	StateTypeDeactivated StateType = "deactivated"
-	StateTypeDeleted     StateType = "deleted"
-)
-
-func StateTypeChoices() []string {
-	return []string{"active", "deactivated", "deleted"}
-}
-
 type TokenOut struct {
 	Description   string    `json:"description"`
 	LastIp        string    `json:"last_ip"`

--- a/handler/privatelink/privatelink.go
+++ b/handler/privatelink/privatelink.go
@@ -258,17 +258,30 @@ func (h *PrivatelinkHandler) ServicePrivatelinkAzureUpdate(ctx context.Context, 
 }
 
 type ConnectionOut struct {
-	DnsName                 string `json:"dns_name"`
-	PrivatelinkConnectionId string `json:"privatelink_connection_id,omitempty"`
-	State                   string `json:"state"`
-	VpcEndpointId           string `json:"vpc_endpoint_id"`
+	DnsName                 string              `json:"dns_name"`
+	PrivatelinkConnectionId string              `json:"privatelink_connection_id,omitempty"`
+	State                   ConnectionStateType `json:"state"`
+	VpcEndpointId           string              `json:"vpc_endpoint_id"`
 }
 type ConnectionOutAlt struct {
-	PrivateEndpointId       string `json:"private_endpoint_id"`
-	PrivatelinkConnectionId string `json:"privatelink_connection_id,omitempty"`
-	State                   string `json:"state"`
-	UserIpAddress           string `json:"user_ip_address"`
+	PrivateEndpointId       string              `json:"private_endpoint_id"`
+	PrivatelinkConnectionId string              `json:"privatelink_connection_id,omitempty"`
+	State                   ConnectionStateType `json:"state"`
+	UserIpAddress           string              `json:"user_ip_address"`
 }
+type ConnectionStateType string
+
+const (
+	ConnectionStateTypePendingUserApproval ConnectionStateType = "pending-user-approval"
+	ConnectionStateTypeUserApproved        ConnectionStateType = "user-approved"
+	ConnectionStateTypeConnected           ConnectionStateType = "connected"
+	ConnectionStateTypeActive              ConnectionStateType = "active"
+)
+
+func ConnectionStateTypeChoices() []string {
+	return []string{"pending-user-approval", "user-approved", "connected", "active"}
+}
+
 type PrivatelinkAvailabilityOut struct {
 	CloudName string `json:"cloud_name"`
 	PriceUsd  string `json:"price_usd"`
@@ -277,76 +290,162 @@ type ServicePrivatelinkAwscreateIn struct {
 	Principals []string `json:"principals"`
 }
 type ServicePrivatelinkAwscreateOut struct {
-	AwsServiceId   string   `json:"aws_service_id,omitempty"`
-	AwsServiceName string   `json:"aws_service_name,omitempty"`
-	Principals     []string `json:"principals"`
-	State          string   `json:"state"`
+	AwsServiceId   string                               `json:"aws_service_id,omitempty"`
+	AwsServiceName string                               `json:"aws_service_name,omitempty"`
+	Principals     []string                             `json:"principals"`
+	State          ServicePrivatelinkAwscreateStateType `json:"state"`
 }
+type ServicePrivatelinkAwscreateStateType string
+
+const (
+	ServicePrivatelinkAwscreateStateTypeCreating ServicePrivatelinkAwscreateStateType = "creating"
+	ServicePrivatelinkAwscreateStateTypeActive   ServicePrivatelinkAwscreateStateType = "active"
+	ServicePrivatelinkAwscreateStateTypeDeleting ServicePrivatelinkAwscreateStateType = "deleting"
+)
+
+func ServicePrivatelinkAwscreateStateTypeChoices() []string {
+	return []string{"creating", "active", "deleting"}
+}
+
 type ServicePrivatelinkAwsdeleteOut struct {
-	AwsServiceId   string   `json:"aws_service_id,omitempty"`
-	AwsServiceName string   `json:"aws_service_name,omitempty"`
-	Principals     []string `json:"principals"`
-	State          string   `json:"state"`
+	AwsServiceId   string                               `json:"aws_service_id,omitempty"`
+	AwsServiceName string                               `json:"aws_service_name,omitempty"`
+	Principals     []string                             `json:"principals"`
+	State          ServicePrivatelinkAwsdeleteStateType `json:"state"`
 }
+type ServicePrivatelinkAwsdeleteStateType string
+
+const (
+	ServicePrivatelinkAwsdeleteStateTypeCreating ServicePrivatelinkAwsdeleteStateType = "creating"
+	ServicePrivatelinkAwsdeleteStateTypeActive   ServicePrivatelinkAwsdeleteStateType = "active"
+	ServicePrivatelinkAwsdeleteStateTypeDeleting ServicePrivatelinkAwsdeleteStateType = "deleting"
+)
+
+func ServicePrivatelinkAwsdeleteStateTypeChoices() []string {
+	return []string{"creating", "active", "deleting"}
+}
+
 type ServicePrivatelinkAwsgetOut struct {
-	AwsServiceId   string   `json:"aws_service_id,omitempty"`
-	AwsServiceName string   `json:"aws_service_name,omitempty"`
-	Principals     []string `json:"principals"`
-	State          string   `json:"state"`
+	AwsServiceId   string                            `json:"aws_service_id,omitempty"`
+	AwsServiceName string                            `json:"aws_service_name,omitempty"`
+	Principals     []string                          `json:"principals"`
+	State          ServicePrivatelinkAwsgetStateType `json:"state"`
 }
+type ServicePrivatelinkAwsgetStateType string
+
+const (
+	ServicePrivatelinkAwsgetStateTypeCreating ServicePrivatelinkAwsgetStateType = "creating"
+	ServicePrivatelinkAwsgetStateTypeActive   ServicePrivatelinkAwsgetStateType = "active"
+	ServicePrivatelinkAwsgetStateTypeDeleting ServicePrivatelinkAwsgetStateType = "deleting"
+)
+
+func ServicePrivatelinkAwsgetStateTypeChoices() []string {
+	return []string{"creating", "active", "deleting"}
+}
+
 type ServicePrivatelinkAwsupdateIn struct {
 	Principals []string `json:"principals"`
 }
 type ServicePrivatelinkAwsupdateOut struct {
-	AwsServiceId   string   `json:"aws_service_id,omitempty"`
-	AwsServiceName string   `json:"aws_service_name,omitempty"`
-	Principals     []string `json:"principals"`
-	State          string   `json:"state"`
+	AwsServiceId   string                               `json:"aws_service_id,omitempty"`
+	AwsServiceName string                               `json:"aws_service_name,omitempty"`
+	Principals     []string                             `json:"principals"`
+	State          ServicePrivatelinkAwsupdateStateType `json:"state"`
 }
+type ServicePrivatelinkAwsupdateStateType string
+
+const (
+	ServicePrivatelinkAwsupdateStateTypeCreating ServicePrivatelinkAwsupdateStateType = "creating"
+	ServicePrivatelinkAwsupdateStateTypeActive   ServicePrivatelinkAwsupdateStateType = "active"
+	ServicePrivatelinkAwsupdateStateTypeDeleting ServicePrivatelinkAwsupdateStateType = "deleting"
+)
+
+func ServicePrivatelinkAwsupdateStateTypeChoices() []string {
+	return []string{"creating", "active", "deleting"}
+}
+
 type ServicePrivatelinkAzureConnectionApprovalOut struct {
-	PrivateEndpointId       string `json:"private_endpoint_id"`
-	PrivatelinkConnectionId string `json:"privatelink_connection_id,omitempty"`
-	State                   string `json:"state"`
-	UserIpAddress           string `json:"user_ip_address"`
+	PrivateEndpointId       string                                             `json:"private_endpoint_id"`
+	PrivatelinkConnectionId string                                             `json:"privatelink_connection_id,omitempty"`
+	State                   ServicePrivatelinkAzureConnectionApprovalStateType `json:"state"`
+	UserIpAddress           string                                             `json:"user_ip_address"`
 }
+type ServicePrivatelinkAzureConnectionApprovalStateType string
+
+const (
+	ServicePrivatelinkAzureConnectionApprovalStateTypePendingUserApproval ServicePrivatelinkAzureConnectionApprovalStateType = "pending-user-approval"
+	ServicePrivatelinkAzureConnectionApprovalStateTypeUserApproved        ServicePrivatelinkAzureConnectionApprovalStateType = "user-approved"
+	ServicePrivatelinkAzureConnectionApprovalStateTypeConnected           ServicePrivatelinkAzureConnectionApprovalStateType = "connected"
+	ServicePrivatelinkAzureConnectionApprovalStateTypeActive              ServicePrivatelinkAzureConnectionApprovalStateType = "active"
+)
+
+func ServicePrivatelinkAzureConnectionApprovalStateTypeChoices() []string {
+	return []string{"pending-user-approval", "user-approved", "connected", "active"}
+}
+
+type ServicePrivatelinkAzureConnectionStateType string
+
+const (
+	ServicePrivatelinkAzureConnectionStateTypePendingUserApproval ServicePrivatelinkAzureConnectionStateType = "pending-user-approval"
+	ServicePrivatelinkAzureConnectionStateTypeUserApproved        ServicePrivatelinkAzureConnectionStateType = "user-approved"
+	ServicePrivatelinkAzureConnectionStateTypeConnected           ServicePrivatelinkAzureConnectionStateType = "connected"
+	ServicePrivatelinkAzureConnectionStateTypeActive              ServicePrivatelinkAzureConnectionStateType = "active"
+)
+
+func ServicePrivatelinkAzureConnectionStateTypeChoices() []string {
+	return []string{"pending-user-approval", "user-approved", "connected", "active"}
+}
+
 type ServicePrivatelinkAzureConnectionUpdateIn struct {
 	UserIpAddress string `json:"user_ip_address"`
 }
 type ServicePrivatelinkAzureConnectionUpdateOut struct {
-	PrivateEndpointId       string `json:"private_endpoint_id"`
-	PrivatelinkConnectionId string `json:"privatelink_connection_id,omitempty"`
-	State                   string `json:"state"`
-	UserIpAddress           string `json:"user_ip_address"`
+	PrivateEndpointId       string                                     `json:"private_endpoint_id"`
+	PrivatelinkConnectionId string                                     `json:"privatelink_connection_id,omitempty"`
+	State                   ServicePrivatelinkAzureConnectionStateType `json:"state"`
+	UserIpAddress           string                                     `json:"user_ip_address"`
 }
 type ServicePrivatelinkAzureCreateIn struct {
 	UserSubscriptionIds []string `json:"user_subscription_ids"`
 }
 type ServicePrivatelinkAzureCreateOut struct {
-	AzureServiceAlias   string   `json:"azure_service_alias,omitempty"`
-	AzureServiceId      string   `json:"azure_service_id,omitempty"`
-	State               string   `json:"state"`
-	UserSubscriptionIds []string `json:"user_subscription_ids"`
+	AzureServiceAlias   string                           `json:"azure_service_alias,omitempty"`
+	AzureServiceId      string                           `json:"azure_service_id,omitempty"`
+	State               ServicePrivatelinkAzureStateType `json:"state"`
+	UserSubscriptionIds []string                         `json:"user_subscription_ids"`
 }
 type ServicePrivatelinkAzureDeleteOut struct {
-	AzureServiceAlias   string   `json:"azure_service_alias,omitempty"`
-	AzureServiceId      string   `json:"azure_service_id,omitempty"`
-	State               string   `json:"state"`
-	UserSubscriptionIds []string `json:"user_subscription_ids"`
+	AzureServiceAlias   string                           `json:"azure_service_alias,omitempty"`
+	AzureServiceId      string                           `json:"azure_service_id,omitempty"`
+	State               ServicePrivatelinkAzureStateType `json:"state"`
+	UserSubscriptionIds []string                         `json:"user_subscription_ids"`
 }
 type ServicePrivatelinkAzureGetOut struct {
-	AzureServiceAlias   string   `json:"azure_service_alias,omitempty"`
-	AzureServiceId      string   `json:"azure_service_id,omitempty"`
-	State               string   `json:"state"`
-	UserSubscriptionIds []string `json:"user_subscription_ids"`
+	AzureServiceAlias   string                           `json:"azure_service_alias,omitempty"`
+	AzureServiceId      string                           `json:"azure_service_id,omitempty"`
+	State               ServicePrivatelinkAzureStateType `json:"state"`
+	UserSubscriptionIds []string                         `json:"user_subscription_ids"`
 }
+type ServicePrivatelinkAzureStateType string
+
+const (
+	ServicePrivatelinkAzureStateTypeCreating ServicePrivatelinkAzureStateType = "creating"
+	ServicePrivatelinkAzureStateTypeActive   ServicePrivatelinkAzureStateType = "active"
+	ServicePrivatelinkAzureStateTypeDeleting ServicePrivatelinkAzureStateType = "deleting"
+)
+
+func ServicePrivatelinkAzureStateTypeChoices() []string {
+	return []string{"creating", "active", "deleting"}
+}
+
 type ServicePrivatelinkAzureUpdateIn struct {
 	UserSubscriptionIds []string `json:"user_subscription_ids"`
 }
 type ServicePrivatelinkAzureUpdateOut struct {
-	AzureServiceAlias   string   `json:"azure_service_alias,omitempty"`
-	AzureServiceId      string   `json:"azure_service_id,omitempty"`
-	State               string   `json:"state"`
-	UserSubscriptionIds []string `json:"user_subscription_ids"`
+	AzureServiceAlias   string                           `json:"azure_service_alias,omitempty"`
+	AzureServiceId      string                           `json:"azure_service_id,omitempty"`
+	State               ServicePrivatelinkAzureStateType `json:"state"`
+	UserSubscriptionIds []string                         `json:"user_subscription_ids"`
 }
 type publicPrivatelinkAvailabilityListOut struct {
 	PrivatelinkAvailability []PrivatelinkAvailabilityOut `json:"privatelink_availability"`

--- a/handler/project/project.go
+++ b/handler/project/project.go
@@ -337,6 +337,19 @@ type AlertOut struct {
 	ServiceType string    `json:"service_type,omitempty"`
 	Severity    string    `json:"severity"`
 }
+type AnyType string
+
+const (
+	AnyTypeAdmin     AnyType = "admin"
+	AnyTypeDeveloper AnyType = "developer"
+	AnyTypeOperator  AnyType = "operator"
+	AnyTypeReadOnly  AnyType = "read_only"
+)
+
+func AnyTypeChoices() []string {
+	return []string{"admin", "developer", "operator", "read_only"}
+}
+
 type BillingCurrencyType string
 
 const (
@@ -391,16 +404,16 @@ type EventOut struct {
 	Time        string `json:"time"`
 }
 type GroupUserOut struct {
-	MemberType  string `json:"member_type"`
-	RealName    string `json:"real_name"`
-	UserEmail   string `json:"user_email"`
-	UserGroupId string `json:"user_group_id"`
+	MemberType  MemberType `json:"member_type"`
+	RealName    string     `json:"real_name"`
+	UserEmail   string     `json:"user_email"`
+	UserGroupId string     `json:"user_group_id"`
 }
 type InvitationOut struct {
-	InviteTime        time.Time `json:"invite_time"`
-	InvitedUserEmail  string    `json:"invited_user_email"`
-	InvitingUserEmail string    `json:"inviting_user_email"`
-	MemberType        string    `json:"member_type"`
+	InviteTime        time.Time  `json:"invite_time"`
+	InvitedUserEmail  string     `json:"invited_user_email"`
+	InvitingUserEmail string     `json:"inviting_user_email"`
+	MemberType        MemberType `json:"member_type"`
 }
 type MemberType string
 
@@ -449,7 +462,7 @@ type ProjectCreateOut struct {
 	AddressLines          []string               `json:"address_lines,omitempty"`
 	AvailableCredits      string                 `json:"available_credits,omitempty"`
 	BillingAddress        string                 `json:"billing_address"`
-	BillingCurrency       string                 `json:"billing_currency,omitempty"`
+	BillingCurrency       BillingCurrencyType    `json:"billing_currency,omitempty"`
 	BillingEmails         []BillingEmailOut      `json:"billing_emails"`
 	BillingExtraText      string                 `json:"billing_extra_text,omitempty"`
 	BillingGroupId        string                 `json:"billing_group_id"`
@@ -481,7 +494,7 @@ type ProjectGetOut struct {
 	AddressLines          []string               `json:"address_lines,omitempty"`
 	AvailableCredits      string                 `json:"available_credits,omitempty"`
 	BillingAddress        string                 `json:"billing_address"`
-	BillingCurrency       string                 `json:"billing_currency,omitempty"`
+	BillingCurrency       BillingCurrencyType    `json:"billing_currency,omitempty"`
 	BillingEmails         []BillingEmailOut      `json:"billing_emails"`
 	BillingExtraText      string                 `json:"billing_extra_text,omitempty"`
 	BillingGroupId        string                 `json:"billing_group_id"`
@@ -520,7 +533,7 @@ type ProjectListOut struct {
 	Projects           []ProjectOut           `json:"projects"`
 }
 type ProjectMembershipOut struct {
-	Any string `json:"ANY,omitempty"`
+	Any AnyType `json:"ANY,omitempty"`
 }
 type ProjectMembershipsOut struct {
 	Any []string `json:"ANY,omitempty"`
@@ -531,7 +544,7 @@ type ProjectOut struct {
 	AddressLines          []string               `json:"address_lines,omitempty"`
 	AvailableCredits      string                 `json:"available_credits,omitempty"`
 	BillingAddress        string                 `json:"billing_address"`
-	BillingCurrency       string                 `json:"billing_currency,omitempty"`
+	BillingCurrency       BillingCurrencyType    `json:"billing_currency,omitempty"`
 	BillingEmails         []BillingEmailOut      `json:"billing_emails"`
 	BillingExtraText      string                 `json:"billing_extra_text,omitempty"`
 	BillingGroupId        string                 `json:"billing_group_id"`
@@ -558,10 +571,10 @@ type ProjectOut struct {
 	ZipCode               string                 `json:"zip_code,omitempty"`
 }
 type ProjectTagsReplaceIn struct {
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags map[string]string `json:"tags"`
 }
 type ProjectTagsUpdateIn struct {
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags map[string]string `json:"tags"`
 }
 type ProjectUpdateIn struct {
 	AccountId                   string              `json:"account_id,omitempty"`
@@ -590,7 +603,7 @@ type ProjectUpdateOut struct {
 	AddressLines          []string               `json:"address_lines,omitempty"`
 	AvailableCredits      string                 `json:"available_credits,omitempty"`
 	BillingAddress        string                 `json:"billing_address"`
-	BillingCurrency       string                 `json:"billing_currency,omitempty"`
+	BillingCurrency       BillingCurrencyType    `json:"billing_currency,omitempty"`
 	BillingEmails         []BillingEmailOut      `json:"billing_emails"`
 	BillingExtraText      string                 `json:"billing_extra_text,omitempty"`
 	BillingGroupId        string                 `json:"billing_group_id"`
@@ -631,19 +644,33 @@ type TechEmailOut struct {
 	Email string `json:"email"`
 }
 type UserOut struct {
-	Auth           []string  `json:"auth"`
-	BillingContact bool      `json:"billing_contact"`
-	CreateTime     time.Time `json:"create_time"`
-	MemberType     string    `json:"member_type"`
-	RealName       string    `json:"real_name,omitempty"`
-	TeamId         string    `json:"team_id"`
-	TeamName       string    `json:"team_name"`
-	UserEmail      string    `json:"user_email"`
+	Auth           []string   `json:"auth"`
+	BillingContact bool       `json:"billing_contact"`
+	CreateTime     time.Time  `json:"create_time"`
+	MemberType     MemberType `json:"member_type"`
+	RealName       string     `json:"real_name,omitempty"`
+	TeamId         string     `json:"team_id"`
+	TeamName       string     `json:"team_name"`
+	UserEmail      string     `json:"user_email"`
 }
+type VpcPeeringConnectionType string
+
+const (
+	VpcPeeringConnectionTypeAwsTgwVpcAttachment     VpcPeeringConnectionType = "aws-tgw-vpc-attachment"
+	VpcPeeringConnectionTypeAwsVpcPeeringConnection VpcPeeringConnectionType = "aws-vpc-peering-connection"
+	VpcPeeringConnectionTypeAzureVnetPeering        VpcPeeringConnectionType = "azure-vnet-peering"
+	VpcPeeringConnectionTypeGoogleVpcPeering        VpcPeeringConnectionType = "google-vpc-peering"
+	VpcPeeringConnectionTypeUpcloudVpcPeering       VpcPeeringConnectionType = "upcloud-vpc-peering"
+)
+
+func VpcPeeringConnectionTypeChoices() []string {
+	return []string{"aws-tgw-vpc-attachment", "aws-vpc-peering-connection", "azure-vnet-peering", "google-vpc-peering", "upcloud-vpc-peering"}
+}
+
 type VpcPeeringConnectionTypeOut struct {
-	CloudName                string `json:"cloud_name"`
-	PriceUsd                 string `json:"price_usd"`
-	VpcPeeringConnectionType string `json:"vpc_peering_connection_type"`
+	CloudName                string                   `json:"cloud_name"`
+	PriceUsd                 string                   `json:"price_usd"`
+	VpcPeeringConnectionType VpcPeeringConnectionType `json:"vpc_peering_connection_type"`
 }
 type listProjectVpcPeeringConnectionTypesOut struct {
 	VpcPeeringConnectionTypes []VpcPeeringConnectionTypeOut `json:"vpc_peering_connection_types"`

--- a/handler/projectbilling/projectbilling.go
+++ b/handler/projectbilling/projectbilling.go
@@ -78,28 +78,103 @@ func (h *ProjectBillingHandler) ProjectInvoiceList(ctx context.Context, project 
 	return out.Invoices, nil
 }
 
+type BillingGroupStateType string
+
+const (
+	BillingGroupStateTypeActive  BillingGroupStateType = "active"
+	BillingGroupStateTypeDeleted BillingGroupStateType = "deleted"
+)
+
+func BillingGroupStateTypeChoices() []string {
+	return []string{"active", "deleted"}
+}
+
 type CreditOut struct {
 	Code           string     `json:"code,omitempty"`
 	ExpireTime     *time.Time `json:"expire_time,omitempty"`
 	RemainingValue string     `json:"remaining_value,omitempty"`
 	StartTime      *time.Time `json:"start_time,omitempty"`
-	Type           string     `json:"type,omitempty"`
+	Type           CreditType `json:"type,omitempty"`
 	Value          string     `json:"value,omitempty"`
 }
-type InvoiceOut struct {
-	BillingGroupId    string     `json:"billing_group_id"`
-	BillingGroupName  string     `json:"billing_group_name"`
-	BillingGroupState string     `json:"billing_group_state"`
-	Currency          string     `json:"currency"`
-	DownloadCookie    string     `json:"download_cookie"`
-	GeneratedAt       *time.Time `json:"generated_at,omitempty"`
-	InvoiceNumber     string     `json:"invoice_number"`
-	PeriodBegin       string     `json:"period_begin"`
-	PeriodEnd         string     `json:"period_end"`
-	State             string     `json:"state"`
-	TotalIncVat       string     `json:"total_inc_vat"`
-	TotalVatZero      string     `json:"total_vat_zero"`
+type CreditType string
+
+const (
+	CreditTypeDiscount    CreditType = "discount"
+	CreditTypeEmployee    CreditType = "employee"
+	CreditTypeEvaluation  CreditType = "evaluation"
+	CreditTypeInternal    CreditType = "internal"
+	CreditTypeOther       CreditType = "other"
+	CreditTypeOutage      CreditType = "outage"
+	CreditTypePartner     CreditType = "partner"
+	CreditTypePromotion   CreditType = "promotion"
+	CreditTypePurchase    CreditType = "purchase"
+	CreditTypeReferral    CreditType = "referral"
+	CreditTypeSponsorship CreditType = "sponsorship"
+	CreditTypeTrial       CreditType = "trial"
+	CreditTypeTrialOver   CreditType = "trial_over"
+)
+
+func CreditTypeChoices() []string {
+	return []string{"discount", "employee", "evaluation", "internal", "other", "outage", "partner", "promotion", "purchase", "referral", "sponsorship", "trial", "trial_over"}
 }
+
+type CurrencyType string
+
+const (
+	CurrencyTypeAud CurrencyType = "AUD"
+	CurrencyTypeCad CurrencyType = "CAD"
+	CurrencyTypeChf CurrencyType = "CHF"
+	CurrencyTypeDkk CurrencyType = "DKK"
+	CurrencyTypeEur CurrencyType = "EUR"
+	CurrencyTypeGbp CurrencyType = "GBP"
+	CurrencyTypeJpy CurrencyType = "JPY"
+	CurrencyTypeNok CurrencyType = "NOK"
+	CurrencyTypeNzd CurrencyType = "NZD"
+	CurrencyTypeSek CurrencyType = "SEK"
+	CurrencyTypeSgd CurrencyType = "SGD"
+	CurrencyTypeUsd CurrencyType = "USD"
+)
+
+func CurrencyTypeChoices() []string {
+	return []string{"AUD", "CAD", "CHF", "DKK", "EUR", "GBP", "JPY", "NOK", "NZD", "SEK", "SGD", "USD"}
+}
+
+type InvoiceOut struct {
+	BillingGroupId    string                `json:"billing_group_id"`
+	BillingGroupName  string                `json:"billing_group_name"`
+	BillingGroupState BillingGroupStateType `json:"billing_group_state"`
+	Currency          CurrencyType          `json:"currency"`
+	DownloadCookie    string                `json:"download_cookie"`
+	GeneratedAt       *time.Time            `json:"generated_at,omitempty"`
+	InvoiceNumber     string                `json:"invoice_number"`
+	PeriodBegin       string                `json:"period_begin"`
+	PeriodEnd         string                `json:"period_end"`
+	State             InvoiceStateType      `json:"state"`
+	TotalIncVat       string                `json:"total_inc_vat"`
+	TotalVatZero      string                `json:"total_vat_zero"`
+}
+type InvoiceStateType string
+
+const (
+	InvoiceStateTypeAccrual                InvoiceStateType = "accrual"
+	InvoiceStateTypeConsolidated           InvoiceStateType = "consolidated"
+	InvoiceStateTypeDue                    InvoiceStateType = "due"
+	InvoiceStateTypeEstimate               InvoiceStateType = "estimate"
+	InvoiceStateTypeFailedCreditCardCharge InvoiceStateType = "failed_credit_card_charge"
+	InvoiceStateTypeFailedNoCreditCard     InvoiceStateType = "failed_no_credit_card"
+	InvoiceStateTypeMailed                 InvoiceStateType = "mailed"
+	InvoiceStateTypeNoPaymentExpected      InvoiceStateType = "no_payment_expected"
+	InvoiceStateTypePaid                   InvoiceStateType = "paid"
+	InvoiceStateTypePartnerMetering        InvoiceStateType = "partner_metering"
+	InvoiceStateTypeUncollectible          InvoiceStateType = "uncollectible"
+	InvoiceStateTypeWaived                 InvoiceStateType = "waived"
+)
+
+func InvoiceStateTypeChoices() []string {
+	return []string{"accrual", "consolidated", "due", "estimate", "failed_credit_card_charge", "failed_no_credit_card", "mailed", "no_payment_expected", "paid", "partner_metering", "uncollectible", "waived"}
+}
+
 type ProjectCreditsClaimIn struct {
 	Code string `json:"code"`
 }
@@ -108,7 +183,7 @@ type ProjectCreditsClaimOut struct {
 	ExpireTime     *time.Time `json:"expire_time,omitempty"`
 	RemainingValue string     `json:"remaining_value,omitempty"`
 	StartTime      *time.Time `json:"start_time,omitempty"`
-	Type           string     `json:"type,omitempty"`
+	Type           CreditType `json:"type,omitempty"`
 	Value          string     `json:"value,omitempty"`
 }
 type projectCreditsClaimOut struct {

--- a/handler/service/service.go
+++ b/handler/service/service.go
@@ -525,16 +525,23 @@ type AccessControlOut struct {
 	RedisAclKeys       []string `json:"redis_acl_keys,omitempty"`
 }
 type AclOut struct {
-	Id         string `json:"id,omitempty"`
-	Permission string `json:"permission"`
-	Topic      string `json:"topic"`
-	Username   string `json:"username"`
+	Id         string         `json:"id,omitempty"`
+	Permission PermissionType `json:"permission"`
+	Topic      string         `json:"topic"`
+	Username   string         `json:"username"`
 }
 type AdditionalRegionOut struct {
 	Cloud       string `json:"cloud"`
 	PauseReason string `json:"pause_reason,omitempty"`
 	Paused      *bool  `json:"paused,omitempty"`
 	Region      string `json:"region,omitempty"`
+}
+type AggregatorOut struct {
+	DefaultVersion         string           `json:"default_version,omitempty"`
+	Description            string           `json:"description"`
+	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	ServicePlans           []ServicePlanOut `json:"service_plans"`
+	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
 type AlertOut struct {
 	CreateTime  time.Time `json:"create_time"`
@@ -545,21 +552,26 @@ type AlertOut struct {
 	ServiceType string    `json:"service_type,omitempty"`
 	Severity    string    `json:"severity"`
 }
-type AnyOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
-	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
-	ServicePlans           []ServicePlanOut `json:"service_plans"`
-	UserConfigSchema       map[string]any   `json:"user_config_schema"`
+type AuthenticationType string
+
+const (
+	AuthenticationTypeNull                AuthenticationType = "null"
+	AuthenticationTypeCachingSha2Password AuthenticationType = "caching_sha2_password"
+	AuthenticationTypeMysqlNativePassword AuthenticationType = "mysql_native_password"
+)
+
+func AuthenticationTypeChoices() []string {
+	return []string{"null", "caching_sha2_password", "mysql_native_password"}
 }
+
 type BackupConfigOut struct {
-	FrequentIntervalMinutes    *int   `json:"frequent_interval_minutes,omitempty"`
-	FrequentOldestAgeMinutes   *int   `json:"frequent_oldest_age_minutes,omitempty"`
-	InfrequentIntervalMinutes  *int   `json:"infrequent_interval_minutes,omitempty"`
-	InfrequentOldestAgeMinutes *int   `json:"infrequent_oldest_age_minutes,omitempty"`
-	Interval                   int    `json:"interval"`
-	MaxCount                   int    `json:"max_count"`
-	RecoveryMode               string `json:"recovery_mode"`
+	FrequentIntervalMinutes    *int             `json:"frequent_interval_minutes,omitempty"`
+	FrequentOldestAgeMinutes   *int             `json:"frequent_oldest_age_minutes,omitempty"`
+	InfrequentIntervalMinutes  *int             `json:"infrequent_interval_minutes,omitempty"`
+	InfrequentOldestAgeMinutes *int             `json:"infrequent_oldest_age_minutes,omitempty"`
+	Interval                   int              `json:"interval"`
+	MaxCount                   int              `json:"max_count"`
+	RecoveryMode               RecoveryModeType `json:"recovery_mode"`
 }
 type BackupOut struct {
 	AdditionalRegions []AdditionalRegionOut `json:"additional_regions,omitempty"`
@@ -568,24 +580,38 @@ type BackupOut struct {
 	DataSize          int                   `json:"data_size"`
 	StorageLocation   string                `json:"storage_location,omitempty"`
 }
+type CassandraOut struct {
+	DefaultVersion         string           `json:"default_version,omitempty"`
+	Description            string           `json:"description"`
+	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	ServicePlans           []ServicePlanOut `json:"service_plans"`
+	UserConfigSchema       map[string]any   `json:"user_config_schema"`
+}
+type ClickhouseOut struct {
+	DefaultVersion         string           `json:"default_version,omitempty"`
+	Description            string           `json:"description"`
+	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	ServicePlans           []ServicePlanOut `json:"service_plans"`
+	UserConfigSchema       map[string]any   `json:"user_config_schema"`
+}
 type ComponentOut struct {
-	Component                 string `json:"component"`
-	Host                      string `json:"host"`
-	KafkaAuthenticationMethod string `json:"kafka_authentication_method,omitempty"`
-	Path                      string `json:"path,omitempty"`
-	Port                      int    `json:"port"`
-	PrivatelinkConnectionId   string `json:"privatelink_connection_id,omitempty"`
-	Route                     string `json:"route"`
-	Ssl                       *bool  `json:"ssl,omitempty"`
-	Usage                     string `json:"usage"`
+	Component                 string                        `json:"component"`
+	Host                      string                        `json:"host"`
+	KafkaAuthenticationMethod KafkaAuthenticationMethodType `json:"kafka_authentication_method,omitempty"`
+	Path                      string                        `json:"path,omitempty"`
+	Port                      int                           `json:"port"`
+	PrivatelinkConnectionId   string                        `json:"privatelink_connection_id,omitempty"`
+	Route                     RouteType                     `json:"route"`
+	Ssl                       *bool                         `json:"ssl,omitempty"`
+	Usage                     UsageType                     `json:"usage"`
 }
 type ConnectionPoolOut struct {
-	ConnectionUri string `json:"connection_uri"`
-	Database      string `json:"database"`
-	PoolMode      string `json:"pool_mode"`
-	PoolName      string `json:"pool_name"`
-	PoolSize      int    `json:"pool_size"`
-	Username      string `json:"username,omitempty"`
+	ConnectionUri string       `json:"connection_uri"`
+	Database      string       `json:"database"`
+	PoolMode      PoolModeType `json:"pool_mode"`
+	PoolName      string       `json:"pool_name"`
+	PoolSize      int          `json:"pool_size"`
+	Username      string       `json:"username,omitempty"`
 }
 type DatabaseOut struct {
 	DatabaseName string `json:"database_name"`
@@ -603,6 +629,13 @@ func DatasetNameTypeChoices() []string {
 	return []string{"pagila"}
 }
 
+type DbOut struct {
+	DefaultVersion         string           `json:"default_version,omitempty"`
+	Description            string           `json:"description"`
+	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	ServicePlans           []ServicePlanOut `json:"service_plans"`
+	UserConfigSchema       map[string]any   `json:"user_config_schema"`
+}
 type DowType string
 
 const (
@@ -619,10 +652,69 @@ func DowTypeChoices() []string {
 	return []string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}
 }
 
+type DowTypeAlt string
+
+const (
+	DowTypeAltMonday    DowTypeAlt = "monday"
+	DowTypeAltTuesday   DowTypeAlt = "tuesday"
+	DowTypeAltWednesday DowTypeAlt = "wednesday"
+	DowTypeAltThursday  DowTypeAlt = "thursday"
+	DowTypeAltFriday    DowTypeAlt = "friday"
+	DowTypeAltSaturday  DowTypeAlt = "saturday"
+	DowTypeAltSunday    DowTypeAlt = "sunday"
+	DowTypeAltNever     DowTypeAlt = "never"
+)
+
+func DowTypeAltChoices() []string {
+	return []string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday", "never"}
+}
+
+type ElasticsearchOut struct {
+	DefaultVersion         string           `json:"default_version,omitempty"`
+	Description            string           `json:"description"`
+	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	ServicePlans           []ServicePlanOut `json:"service_plans"`
+	UserConfigSchema       map[string]any   `json:"user_config_schema"`
+}
+type FlinkOut struct {
+	DefaultVersion         string           `json:"default_version,omitempty"`
+	Description            string           `json:"description"`
+	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	ServicePlans           []ServicePlanOut `json:"service_plans"`
+	UserConfigSchema       map[string]any   `json:"user_config_schema"`
+}
+type GrafanaOut struct {
+	DefaultVersion         string           `json:"default_version,omitempty"`
+	Description            string           `json:"description"`
+	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	ServicePlans           []ServicePlanOut `json:"service_plans"`
+	UserConfigSchema       map[string]any   `json:"user_config_schema"`
+}
+type InfluxdbOut struct {
+	DefaultVersion         string           `json:"default_version,omitempty"`
+	Description            string           `json:"description"`
+	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	ServicePlans           []ServicePlanOut `json:"service_plans"`
+	UserConfigSchema       map[string]any   `json:"user_config_schema"`
+}
 type IntegrationStatusOut struct {
 	State          StateOut `json:"state"`
 	StatusUserDesc string   `json:"status_user_desc"`
 }
+type IntegrationStatusType string
+
+const (
+	IntegrationStatusTypeFailed   IntegrationStatusType = "failed"
+	IntegrationStatusTypeInactive IntegrationStatusType = "inactive"
+	IntegrationStatusTypeRunning  IntegrationStatusType = "running"
+	IntegrationStatusTypeStarting IntegrationStatusType = "starting"
+	IntegrationStatusTypeUnknown  IntegrationStatusType = "unknown"
+)
+
+func IntegrationStatusTypeChoices() []string {
+	return []string{"failed", "inactive", "running", "starting", "unknown"}
+}
+
 type IntegrationType string
 
 const (
@@ -647,6 +739,7 @@ const (
 	IntegrationTypeInternalConnectivity              IntegrationType = "internal_connectivity"
 	IntegrationTypeJolokia                           IntegrationType = "jolokia"
 	IntegrationTypeKafkaConnect                      IntegrationType = "kafka_connect"
+	IntegrationTypeKafkaConnectPostgresql            IntegrationType = "kafka_connect_postgresql"
 	IntegrationTypeKafkaLogs                         IntegrationType = "kafka_logs"
 	IntegrationTypeKafkaMirrormaker                  IntegrationType = "kafka_mirrormaker"
 	IntegrationTypeLogs                              IntegrationType = "logs"
@@ -668,14 +761,99 @@ const (
 )
 
 func IntegrationTypeChoices() []string {
-	return []string{"alertmanager", "autoscaler", "caching", "cassandra_cross_service_cluster", "clickhouse_credentials", "clickhouse_kafka", "clickhouse_postgresql", "dashboard", "datadog", "datasource", "external_aws_cloudwatch_logs", "external_aws_cloudwatch_metrics", "external_elasticsearch_logs", "external_google_cloud_logging", "external_opensearch_logs", "flink", "flink_external_bigquery", "flink_external_kafka", "internal_connectivity", "jolokia", "kafka_connect", "kafka_logs", "kafka_mirrormaker", "logs", "m3aggregator", "m3coordinator", "metrics", "opensearch_cross_cluster_replication", "opensearch_cross_cluster_search", "prometheus", "read_replica", "rsyslog", "schema_registry_proxy", "stresstester", "thanoscompactor", "thanosquery", "thanosstore", "vector", "vmalert"}
+	return []string{"alertmanager", "autoscaler", "caching", "cassandra_cross_service_cluster", "clickhouse_credentials", "clickhouse_kafka", "clickhouse_postgresql", "dashboard", "datadog", "datasource", "external_aws_cloudwatch_logs", "external_aws_cloudwatch_metrics", "external_elasticsearch_logs", "external_google_cloud_logging", "external_opensearch_logs", "flink", "flink_external_bigquery", "flink_external_kafka", "internal_connectivity", "jolokia", "kafka_connect", "kafka_connect_postgresql", "kafka_logs", "kafka_mirrormaker", "logs", "m3aggregator", "m3coordinator", "metrics", "opensearch_cross_cluster_replication", "opensearch_cross_cluster_search", "prometheus", "read_replica", "rsyslog", "schema_registry_proxy", "stresstester", "thanoscompactor", "thanosquery", "thanosstore", "vector", "vmalert"}
+}
+
+type KafkaAuthenticationMethodType string
+
+const (
+	KafkaAuthenticationMethodTypeCertificate KafkaAuthenticationMethodType = "certificate"
+	KafkaAuthenticationMethodTypeSasl        KafkaAuthenticationMethodType = "sasl"
+)
+
+func KafkaAuthenticationMethodTypeChoices() []string {
+	return []string{"certificate", "sasl"}
+}
+
+type KafkaConnectOut struct {
+	DefaultVersion         string           `json:"default_version,omitempty"`
+	Description            string           `json:"description"`
+	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	ServicePlans           []ServicePlanOut `json:"service_plans"`
+	UserConfigSchema       map[string]any   `json:"user_config_schema"`
+}
+type KafkaMirrormakerOut struct {
+	DefaultVersion         string           `json:"default_version,omitempty"`
+	Description            string           `json:"description"`
+	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	ServicePlans           []ServicePlanOut `json:"service_plans"`
+	UserConfigSchema       map[string]any   `json:"user_config_schema"`
+}
+type KafkaOut struct {
+	DefaultVersion         string           `json:"default_version,omitempty"`
+	Description            string           `json:"description"`
+	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	ServicePlans           []ServicePlanOut `json:"service_plans"`
+	UserConfigSchema       map[string]any   `json:"user_config_schema"`
+}
+type LevelType string
+
+const (
+	LevelTypeNotice  LevelType = "notice"
+	LevelTypeWarning LevelType = "warning"
+)
+
+func LevelTypeChoices() []string {
+	return []string{"notice", "warning"}
+}
+
+type LikelyErrorCauseType string
+
+const (
+	LikelyErrorCauseTypeNull        LikelyErrorCauseType = "null"
+	LikelyErrorCauseTypeDestination LikelyErrorCauseType = "destination"
+	LikelyErrorCauseTypeIntegration LikelyErrorCauseType = "integration"
+	LikelyErrorCauseTypeSource      LikelyErrorCauseType = "source"
+	LikelyErrorCauseTypeUnknown     LikelyErrorCauseType = "unknown"
+)
+
+func LikelyErrorCauseTypeChoices() []string {
+	return []string{"null", "destination", "integration", "source", "unknown"}
 }
 
 type ListProjectServiceTypesOut struct {
-	Any *AnyOut `json:"ANY,omitempty"`
+	Cassandra        *CassandraOut        `json:"cassandra,omitempty"`
+	Clickhouse       *ClickhouseOut       `json:"clickhouse,omitempty"`
+	Elasticsearch    *ElasticsearchOut    `json:"elasticsearch,omitempty"`
+	Flink            *FlinkOut            `json:"flink,omitempty"`
+	Grafana          *GrafanaOut          `json:"grafana,omitempty"`
+	Influxdb         *InfluxdbOut         `json:"influxdb,omitempty"`
+	Kafka            *KafkaOut            `json:"kafka,omitempty"`
+	KafkaConnect     *KafkaConnectOut     `json:"kafka_connect,omitempty"`
+	KafkaMirrormaker *KafkaMirrormakerOut `json:"kafka_mirrormaker,omitempty"`
+	M3Aggregator     *AggregatorOut       `json:"m3aggregator,omitempty"`
+	M3Db             *DbOut               `json:"m3db,omitempty"`
+	Mysql            *MysqlOut            `json:"mysql,omitempty"`
+	Opensearch       *OpensearchOut       `json:"opensearch,omitempty"`
+	Pg               *PgOut               `json:"pg,omitempty"`
+	Redis            *RedisOut            `json:"redis,omitempty"`
 }
 type ListPublicServiceTypesOut struct {
-	Any *AnyOut `json:"ANY,omitempty"`
+	Cassandra        *CassandraOut        `json:"cassandra,omitempty"`
+	Clickhouse       *ClickhouseOut       `json:"clickhouse,omitempty"`
+	Elasticsearch    *ElasticsearchOut    `json:"elasticsearch,omitempty"`
+	Flink            *FlinkOut            `json:"flink,omitempty"`
+	Grafana          *GrafanaOut          `json:"grafana,omitempty"`
+	Influxdb         *InfluxdbOut         `json:"influxdb,omitempty"`
+	Kafka            *KafkaOut            `json:"kafka,omitempty"`
+	KafkaConnect     *KafkaConnectOut     `json:"kafka_connect,omitempty"`
+	KafkaMirrormaker *KafkaMirrormakerOut `json:"kafka_mirrormaker,omitempty"`
+	M3Aggregator     *AggregatorOut       `json:"m3aggregator,omitempty"`
+	M3Db             *DbOut               `json:"m3db,omitempty"`
+	Mysql            *MysqlOut            `json:"mysql,omitempty"`
+	Opensearch       *OpensearchOut       `json:"opensearch,omitempty"`
+	Pg               *PgOut               `json:"pg,omitempty"`
+	Redis            *RedisOut            `json:"redis,omitempty"`
 }
 type LogOut struct {
 	Msg  string `json:"msg"`
@@ -687,10 +865,21 @@ type MaintenanceIn struct {
 	Time string  `json:"time,omitempty"`
 }
 type MaintenanceOut struct {
-	Dow     string      `json:"dow"`
+	Dow     DowTypeAlt  `json:"dow"`
 	Time    string      `json:"time"`
 	Updates []UpdateOut `json:"updates"`
 }
+type MasterLinkStatusType string
+
+const (
+	MasterLinkStatusTypeUp   MasterLinkStatusType = "up"
+	MasterLinkStatusTypeDown MasterLinkStatusType = "down"
+)
+
+func MasterLinkStatusTypeChoices() []string {
+	return []string{"up", "down"}
+}
+
 type MetadataOut struct {
 	EndOfLifeHelpArticleUrl string     `json:"end_of_life_help_article_url,omitempty"`
 	EndOfLifePolicyUrl      string     `json:"end_of_life_policy_url,omitempty"`
@@ -702,39 +891,108 @@ type MethodType string
 
 const (
 	MethodTypeDump        MethodType = "dump"
+	MethodTypeMysqldump   MethodType = "mysqldump"
+	MethodTypePgDump      MethodType = "pg_dump"
 	MethodTypeReplication MethodType = "replication"
+	MethodTypeScan        MethodType = "scan"
 )
 
 func MethodTypeChoices() []string {
+	return []string{"dump", "mysqldump", "pg_dump", "replication", "scan"}
+}
+
+type MethodTypeAlt string
+
+const (
+	MethodTypeAltDump        MethodTypeAlt = "dump"
+	MethodTypeAltReplication MethodTypeAlt = "replication"
+)
+
+func MethodTypeAltChoices() []string {
 	return []string{"dump", "replication"}
 }
 
 type MigrationCheckIn struct {
-	IgnoreDbs         string     `json:"ignore_dbs,omitempty"`
-	Method            MethodType `json:"method,omitempty"`
-	SourceProjectName string     `json:"source_project_name,omitempty"`
-	SourceServiceName string     `json:"source_service_name,omitempty"`
-	SourceServiceUri  string     `json:"source_service_uri,omitempty"`
+	IgnoreDbs         string        `json:"ignore_dbs,omitempty"`
+	Method            MethodTypeAlt `json:"method,omitempty"`
+	SourceProjectName string        `json:"source_project_name,omitempty"`
+	SourceServiceName string        `json:"source_service_name,omitempty"`
+	SourceServiceUri  string        `json:"source_service_uri,omitempty"`
 }
 type MigrationDetailOut struct {
-	Dbname string `json:"dbname"`
-	Error  string `json:"error,omitempty"`
-	Method string `json:"method"`
-	Status string `json:"status"`
+	Dbname string                    `json:"dbname"`
+	Error  string                    `json:"error,omitempty"`
+	Method MethodType                `json:"method"`
+	Status MigrationDetailStatusType `json:"status"`
 }
+type MigrationDetailStatusType string
+
+const (
+	MigrationDetailStatusTypeDone    MigrationDetailStatusType = "done"
+	MigrationDetailStatusTypeFailed  MigrationDetailStatusType = "failed"
+	MigrationDetailStatusTypeRunning MigrationDetailStatusType = "running"
+	MigrationDetailStatusTypeSyncing MigrationDetailStatusType = "syncing"
+)
+
+func MigrationDetailStatusTypeChoices() []string {
+	return []string{"done", "failed", "running", "syncing"}
+}
+
 type MigrationOut struct {
-	Error                  string `json:"error,omitempty"`
-	MasterLastIoSecondsAgo *int   `json:"master_last_io_seconds_ago,omitempty"`
-	MasterLinkStatus       string `json:"master_link_status,omitempty"`
-	Method                 string `json:"method"`
-	Status                 string `json:"status"`
+	Error                  string               `json:"error,omitempty"`
+	MasterLastIoSecondsAgo *int                 `json:"master_last_io_seconds_ago,omitempty"`
+	MasterLinkStatus       MasterLinkStatusType `json:"master_link_status,omitempty"`
+	Method                 MethodType           `json:"method"`
+	Status                 MigrationStatusType  `json:"status"`
+}
+type MigrationStatusType string
+
+const (
+	MigrationStatusTypeDone    MigrationStatusType = "done"
+	MigrationStatusTypeFailed  MigrationStatusType = "failed"
+	MigrationStatusTypeRunning MigrationStatusType = "running"
+	MigrationStatusTypeSyncing MigrationStatusType = "syncing"
+)
+
+func MigrationStatusTypeChoices() []string {
+	return []string{"done", "failed", "running", "syncing"}
+}
+
+type MysqlOut struct {
+	DefaultVersion         string           `json:"default_version,omitempty"`
+	Description            string           `json:"description"`
+	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	ServicePlans           []ServicePlanOut `json:"service_plans"`
+	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
 type NodeStateOut struct {
 	Name            string              `json:"name"`
 	ProgressUpdates []ProgressUpdateOut `json:"progress_updates,omitempty"`
-	Role            string              `json:"role,omitempty"`
+	Role            RoleType            `json:"role,omitempty"`
 	Shard           *ShardOut           `json:"shard,omitempty"`
-	State           string              `json:"state"`
+	State           NodeStateType       `json:"state"`
+}
+type NodeStateType string
+
+const (
+	NodeStateTypeLeaving     NodeStateType = "leaving"
+	NodeStateTypeRunning     NodeStateType = "running"
+	NodeStateTypeSettingUpVm NodeStateType = "setting_up_vm"
+	NodeStateTypeSyncingData NodeStateType = "syncing_data"
+	NodeStateTypeTimingOut   NodeStateType = "timing_out"
+	NodeStateTypeUnknown     NodeStateType = "unknown"
+)
+
+func NodeStateTypeChoices() []string {
+	return []string{"leaving", "running", "setting_up_vm", "syncing_data", "timing_out", "unknown"}
+}
+
+type OpensearchOut struct {
+	DefaultVersion         string           `json:"default_version,omitempty"`
+	Description            string           `json:"description"`
+	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	ServicePlans           []ServicePlanOut `json:"service_plans"`
+	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
 type PeriodType string
 
@@ -750,13 +1008,69 @@ func PeriodTypeChoices() []string {
 	return []string{"hour", "day", "week", "month", "year"}
 }
 
+type PermissionType string
+
+const (
+	PermissionTypeAdmin     PermissionType = "admin"
+	PermissionTypeRead      PermissionType = "read"
+	PermissionTypeReadwrite PermissionType = "readwrite"
+	PermissionTypeWrite     PermissionType = "write"
+)
+
+func PermissionTypeChoices() []string {
+	return []string{"admin", "read", "readwrite", "write"}
+}
+
+type PermissionTypeAlt string
+
+const (
+	PermissionTypeAltSchemaRegistryRead  PermissionTypeAlt = "schema_registry_read"
+	PermissionTypeAltSchemaRegistryWrite PermissionTypeAlt = "schema_registry_write"
+)
+
+func PermissionTypeAltChoices() []string {
+	return []string{"schema_registry_read", "schema_registry_write"}
+}
+
+type PgOut struct {
+	DefaultVersion         string           `json:"default_version,omitempty"`
+	Description            string           `json:"description"`
+	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	ServicePlans           []ServicePlanOut `json:"service_plans"`
+	UserConfigSchema       map[string]any   `json:"user_config_schema"`
+}
+type PhaseType string
+
+const (
+	PhaseTypePrepare    PhaseType = "prepare"
+	PhaseTypeBasebackup PhaseType = "basebackup"
+	PhaseTypeStream     PhaseType = "stream"
+	PhaseTypeFinalize   PhaseType = "finalize"
+)
+
+func PhaseTypeChoices() []string {
+	return []string{"prepare", "basebackup", "stream", "finalize"}
+}
+
+type PoolModeType string
+
+const (
+	PoolModeTypeSession     PoolModeType = "session"
+	PoolModeTypeTransaction PoolModeType = "transaction"
+	PoolModeTypeStatement   PoolModeType = "statement"
+)
+
+func PoolModeTypeChoices() []string {
+	return []string{"session", "transaction", "statement"}
+}
+
 type ProgressUpdateOut struct {
-	Completed bool   `json:"completed"`
-	Current   *int   `json:"current,omitempty"`
-	Max       *int   `json:"max,omitempty"`
-	Min       *int   `json:"min,omitempty"`
-	Phase     string `json:"phase"`
-	Unit      string `json:"unit,omitempty"`
+	Completed bool      `json:"completed"`
+	Current   *int      `json:"current,omitempty"`
+	Max       *int      `json:"max,omitempty"`
+	Min       *int      `json:"min,omitempty"`
+	Phase     PhaseType `json:"phase"`
+	Unit      UnitType  `json:"unit,omitempty"`
 }
 type ProjectGetServiceLogsIn struct {
 	Limit     *int          `json:"limit,omitempty"`
@@ -769,10 +1083,10 @@ type ProjectGetServiceLogsOut struct {
 	Offset         string   `json:"offset"`
 }
 type ProjectServiceTagsReplaceIn struct {
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags map[string]string `json:"tags"`
 }
 type ProjectServiceTagsUpdateIn struct {
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags map[string]string `json:"tags"`
 }
 type QueryOut struct {
 	ActiveChannelSubscriptions                *int     `json:"active_channel_subscriptions,omitempty"`
@@ -815,15 +1129,58 @@ type QueryOut struct {
 	Waiting                                   *bool    `json:"waiting,omitempty"`
 	XactStart                                 string   `json:"xact_start,omitempty"`
 }
+type RecoveryModeType string
+
+const (
+	RecoveryModeTypeBasic RecoveryModeType = "basic"
+	RecoveryModeTypePitr  RecoveryModeType = "pitr"
+)
+
+func RecoveryModeTypeChoices() []string {
+	return []string{"basic", "pitr"}
+}
+
+type RedisOut struct {
+	DefaultVersion         string           `json:"default_version,omitempty"`
+	Description            string           `json:"description"`
+	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	ServicePlans           []ServicePlanOut `json:"service_plans"`
+	UserConfigSchema       map[string]any   `json:"user_config_schema"`
+}
 type ResultCodeOut struct {
 	Code   string `json:"code"`
 	Dbname string `json:"dbname,omitempty"`
 }
+type RoleType string
+
+const (
+	RoleTypeMaster      RoleType = "master"
+	RoleTypeStandby     RoleType = "standby"
+	RoleTypeReadReplica RoleType = "read-replica"
+)
+
+func RoleTypeChoices() []string {
+	return []string{"master", "standby", "read-replica"}
+}
+
+type RouteType string
+
+const (
+	RouteTypeDynamic     RouteType = "dynamic"
+	RouteTypePublic      RouteType = "public"
+	RouteTypePrivate     RouteType = "private"
+	RouteTypePrivatelink RouteType = "privatelink"
+)
+
+func RouteTypeChoices() []string {
+	return []string{"dynamic", "public", "private", "privatelink"}
+}
+
 type SchemaRegistryAclOut struct {
-	Id         string `json:"id,omitempty"`
-	Permission string `json:"permission"`
-	Resource   string `json:"resource"`
-	Username   string `json:"username"`
+	Id         string            `json:"id,omitempty"`
+	Permission PermissionTypeAlt `json:"permission"`
+	Resource   string            `json:"resource"`
+	Username   string            `json:"username"`
 }
 type ServiceBackupToAnotherRegionReportIn struct {
 	Period PeriodType `json:"period,omitempty"`
@@ -878,7 +1235,7 @@ type ServiceCreateOut struct {
 	ServiceTypeDescription string                   `json:"service_type_description,omitempty"`
 	ServiceUri             string                   `json:"service_uri"`
 	ServiceUriParams       map[string]any           `json:"service_uri_params,omitempty"`
-	State                  string                   `json:"state"`
+	State                  ServiceStateType         `json:"state"`
 	Tags                   map[string]string        `json:"tags,omitempty"`
 	TechEmails             []TechEmailOut           `json:"tech_emails,omitempty"`
 	TerminationProtection  bool                     `json:"termination_protection"`
@@ -925,7 +1282,7 @@ type ServiceGetOut struct {
 	ServiceTypeDescription string                   `json:"service_type_description,omitempty"`
 	ServiceUri             string                   `json:"service_uri"`
 	ServiceUriParams       map[string]any           `json:"service_uri_params,omitempty"`
-	State                  string                   `json:"state"`
+	State                  ServiceStateType         `json:"state"`
 	Tags                   map[string]string        `json:"tags,omitempty"`
 	TechEmails             []TechEmailOut           `json:"tech_emails,omitempty"`
 	TerminationProtection  bool                     `json:"termination_protection"`
@@ -971,11 +1328,22 @@ type ServiceMetricsFetchIn struct {
 	Period PeriodType `json:"period,omitempty"`
 }
 type ServiceNotificationOut struct {
-	Level    string      `json:"level"`
-	Message  string      `json:"message"`
-	Metadata MetadataOut `json:"metadata"`
-	Type     string      `json:"type"`
+	Level    LevelType               `json:"level"`
+	Message  string                  `json:"message"`
+	Metadata MetadataOut             `json:"metadata"`
+	Type     ServiceNotificationType `json:"type"`
 }
+type ServiceNotificationType string
+
+const (
+	ServiceNotificationTypeServiceEndOfLife         ServiceNotificationType = "service_end_of_life"
+	ServiceNotificationTypeServicePoweredOffRemoval ServiceNotificationType = "service_powered_off_removal"
+)
+
+func ServiceNotificationTypeChoices() []string {
+	return []string{"service_end_of_life", "service_powered_off_removal"}
+}
+
 type ServiceOut struct {
 	Acl                    []AclOut                 `json:"acl,omitempty"`
 	Backups                []BackupOut              `json:"backups,omitempty"`
@@ -1005,7 +1373,7 @@ type ServiceOut struct {
 	ServiceTypeDescription string                   `json:"service_type_description,omitempty"`
 	ServiceUri             string                   `json:"service_uri"`
 	ServiceUriParams       map[string]any           `json:"service_uri_params,omitempty"`
-	State                  string                   `json:"state"`
+	State                  ServiceStateType         `json:"state"`
 	Tags                   map[string]string        `json:"tags,omitempty"`
 	TechEmails             []TechEmailOut           `json:"tech_emails,omitempty"`
 	TerminationProtection  bool                     `json:"termination_protection"`
@@ -1028,6 +1396,19 @@ type ServiceQueryActivityIn struct {
 	Offset  *int   `json:"offset,omitempty"`
 	OrderBy string `json:"order_by,omitempty"`
 }
+type ServiceStateType string
+
+const (
+	ServiceStateTypePoweroff    ServiceStateType = "POWEROFF"
+	ServiceStateTypeRebalancing ServiceStateType = "REBALANCING"
+	ServiceStateTypeRebuilding  ServiceStateType = "REBUILDING"
+	ServiceStateTypeRunning     ServiceStateType = "RUNNING"
+)
+
+func ServiceStateTypeChoices() []string {
+	return []string{"POWEROFF", "REBALANCING", "REBUILDING", "RUNNING"}
+}
+
 type ServiceTaskCreateIn struct {
 	DatasetImport  *DatasetImportIn  `json:"dataset_import,omitempty"`
 	MigrationCheck *MigrationCheckIn `json:"migration_check,omitempty"`
@@ -1093,7 +1474,7 @@ type ServiceUpdateOut struct {
 	ServiceTypeDescription string                   `json:"service_type_description,omitempty"`
 	ServiceUri             string                   `json:"service_uri"`
 	ServiceUriParams       map[string]any           `json:"service_uri_params,omitempty"`
-	State                  string                   `json:"state"`
+	State                  ServiceStateType         `json:"state"`
 	Tags                   map[string]string        `json:"tags,omitempty"`
 	TechEmails             []TechEmailOut           `json:"tech_emails,omitempty"`
 	TerminationProtection  bool                     `json:"termination_protection"`
@@ -1103,18 +1484,32 @@ type ServiceUpdateOut struct {
 	Users                  []UserOut                `json:"users,omitempty"`
 }
 type ServiceVersionOut struct {
-	AivenEndOfLifeTime      *time.Time `json:"aiven_end_of_life_time,omitempty"`
-	AvailabilityEndTime     *time.Time `json:"availability_end_time,omitempty"`
-	AvailabilityStartTime   *time.Time `json:"availability_start_time,omitempty"`
-	EndOfLifeHelpArticleUrl string     `json:"end_of_life_help_article_url,omitempty"`
-	MajorVersion            string     `json:"major_version,omitempty"`
-	ServiceType             string     `json:"service_type,omitempty"`
-	State                   string     `json:"state,omitempty"`
-	TerminationTime         *time.Time `json:"termination_time,omitempty"`
-	UpgradeToServiceType    string     `json:"upgrade_to_service_type,omitempty"`
-	UpgradeToVersion        string     `json:"upgrade_to_version,omitempty"`
-	UpstreamEndOfLifeTime   *time.Time `json:"upstream_end_of_life_time,omitempty"`
+	AivenEndOfLifeTime      *time.Time              `json:"aiven_end_of_life_time,omitempty"`
+	AvailabilityEndTime     *time.Time              `json:"availability_end_time,omitempty"`
+	AvailabilityStartTime   *time.Time              `json:"availability_start_time,omitempty"`
+	EndOfLifeHelpArticleUrl string                  `json:"end_of_life_help_article_url,omitempty"`
+	MajorVersion            string                  `json:"major_version,omitempty"`
+	ServiceType             string                  `json:"service_type,omitempty"`
+	State                   ServiceVersionStateType `json:"state,omitempty"`
+	TerminationTime         *time.Time              `json:"termination_time,omitempty"`
+	UpgradeToServiceType    string                  `json:"upgrade_to_service_type,omitempty"`
+	UpgradeToVersion        string                  `json:"upgrade_to_version,omitempty"`
+	UpstreamEndOfLifeTime   *time.Time              `json:"upstream_end_of_life_time,omitempty"`
 }
+type ServiceVersionStateType string
+
+const (
+	ServiceVersionStateTypeAvailable   ServiceVersionStateType = "available"
+	ServiceVersionStateTypeEol         ServiceVersionStateType = "eol"
+	ServiceVersionStateTypePreview     ServiceVersionStateType = "preview"
+	ServiceVersionStateTypeTerminated  ServiceVersionStateType = "terminated"
+	ServiceVersionStateTypeUnavailable ServiceVersionStateType = "unavailable"
+)
+
+func ServiceVersionStateTypeChoices() []string {
+	return []string{"available", "eol", "preview", "terminated", "unavailable"}
+}
+
 type ShardOut struct {
 	Name     string `json:"name,omitempty"`
 	Position *int   `json:"position,omitempty"`
@@ -1131,10 +1526,10 @@ func SortOrderTypeChoices() []string {
 }
 
 type StateOut struct {
-	Errors           []string       `json:"errors"`
-	LikelyErrorCause string         `json:"likely_error_cause,omitempty"`
-	Nodes            map[string]any `json:"nodes"`
-	Status           string         `json:"status"`
+	Errors           []string              `json:"errors"`
+	LikelyErrorCause LikelyErrorCauseType  `json:"likely_error_cause,omitempty"`
+	Nodes            map[string]any        `json:"nodes"`
+	Status           IntegrationStatusType `json:"status"`
 }
 type TargetVersionType string
 
@@ -1169,31 +1564,67 @@ type TechEmailOut struct {
 	Email string `json:"email"`
 }
 type TopicOut struct {
-	CleanupPolicy     string `json:"cleanup_policy"`
-	MinInsyncReplicas int    `json:"min_insync_replicas"`
-	Partitions        int    `json:"partitions"`
-	Replication       int    `json:"replication"`
-	RetentionBytes    int    `json:"retention_bytes"`
-	RetentionHours    int    `json:"retention_hours"`
-	State             string `json:"state,omitempty"`
-	TopicName         string `json:"topic_name"`
+	CleanupPolicy     string         `json:"cleanup_policy"`
+	MinInsyncReplicas int            `json:"min_insync_replicas"`
+	Partitions        int            `json:"partitions"`
+	Replication       int            `json:"replication"`
+	RetentionBytes    int            `json:"retention_bytes"`
+	RetentionHours    int            `json:"retention_hours"`
+	State             TopicStateType `json:"state,omitempty"`
+	TopicName         string         `json:"topic_name"`
 }
+type TopicStateType string
+
+const (
+	TopicStateTypeActive      TopicStateType = "ACTIVE"
+	TopicStateTypeConfiguring TopicStateType = "CONFIGURING"
+	TopicStateTypeDeleting    TopicStateType = "DELETING"
+)
+
+func TopicStateTypeChoices() []string {
+	return []string{"ACTIVE", "CONFIGURING", "DELETING"}
+}
+
+type UnitType string
+
+const (
+	UnitTypeBinlogs           UnitType = "binlogs"
+	UnitTypeBytesCompressed   UnitType = "bytes_compressed"
+	UnitTypeBytesUncompressed UnitType = "bytes_uncompressed"
+	UnitTypeWalLsn            UnitType = "wal_lsn"
+)
+
+func UnitTypeChoices() []string {
+	return []string{"binlogs", "bytes_compressed", "bytes_uncompressed", "wal_lsn"}
+}
+
 type UpdateOut struct {
 	Deadline    string     `json:"deadline,omitempty"`
 	Description string     `json:"description,omitempty"`
 	StartAfter  string     `json:"start_after,omitempty"`
 	StartAt     *time.Time `json:"start_at,omitempty"`
 }
+type UsageType string
+
+const (
+	UsageTypePrimary UsageType = "primary"
+	UsageTypeReplica UsageType = "replica"
+)
+
+func UsageTypeChoices() []string {
+	return []string{"primary", "replica"}
+}
+
 type UserOut struct {
-	AccessCert                    string            `json:"access_cert,omitempty"`
-	AccessCertNotValidAfterTime   *time.Time        `json:"access_cert_not_valid_after_time,omitempty"`
-	AccessControl                 *AccessControlOut `json:"access_control,omitempty"`
-	AccessKey                     string            `json:"access_key,omitempty"`
-	Authentication                string            `json:"authentication,omitempty"`
-	ExpiringCertNotValidAfterTime *time.Time        `json:"expiring_cert_not_valid_after_time,omitempty"`
-	Password                      string            `json:"password"`
-	Type                          string            `json:"type"`
-	Username                      string            `json:"username"`
+	AccessCert                    string             `json:"access_cert,omitempty"`
+	AccessCertNotValidAfterTime   *time.Time         `json:"access_cert_not_valid_after_time,omitempty"`
+	AccessControl                 *AccessControlOut  `json:"access_control,omitempty"`
+	AccessKey                     string             `json:"access_key,omitempty"`
+	Authentication                AuthenticationType `json:"authentication,omitempty"`
+	ExpiringCertNotValidAfterTime *time.Time         `json:"expiring_cert_not_valid_after_time,omitempty"`
+	Password                      string             `json:"password"`
+	Type                          string             `json:"type"`
+	Username                      string             `json:"username"`
 }
 type listProjectServiceTypesOut struct {
 	ServiceTypes ListProjectServiceTypesOut `json:"service_types"`

--- a/handler/serviceintegration/serviceintegration.go
+++ b/handler/serviceintegration/serviceintegration.go
@@ -260,6 +260,20 @@ type IntegrationStatusOut struct {
 	State          StateOut `json:"state"`
 	StatusUserDesc string   `json:"status_user_desc"`
 }
+type IntegrationStatusType string
+
+const (
+	IntegrationStatusTypeFailed   IntegrationStatusType = "failed"
+	IntegrationStatusTypeInactive IntegrationStatusType = "inactive"
+	IntegrationStatusTypeRunning  IntegrationStatusType = "running"
+	IntegrationStatusTypeStarting IntegrationStatusType = "starting"
+	IntegrationStatusTypeUnknown  IntegrationStatusType = "unknown"
+)
+
+func IntegrationStatusTypeChoices() []string {
+	return []string{"failed", "inactive", "running", "starting", "unknown"}
+}
+
 type IntegrationType string
 
 const (
@@ -284,6 +298,7 @@ const (
 	IntegrationTypeInternalConnectivity              IntegrationType = "internal_connectivity"
 	IntegrationTypeJolokia                           IntegrationType = "jolokia"
 	IntegrationTypeKafkaConnect                      IntegrationType = "kafka_connect"
+	IntegrationTypeKafkaConnectPostgresql            IntegrationType = "kafka_connect_postgresql"
 	IntegrationTypeKafkaLogs                         IntegrationType = "kafka_logs"
 	IntegrationTypeKafkaMirrormaker                  IntegrationType = "kafka_mirrormaker"
 	IntegrationTypeLogs                              IntegrationType = "logs"
@@ -305,7 +320,7 @@ const (
 )
 
 func IntegrationTypeChoices() []string {
-	return []string{"alertmanager", "autoscaler", "caching", "cassandra_cross_service_cluster", "clickhouse_credentials", "clickhouse_kafka", "clickhouse_postgresql", "dashboard", "datadog", "datasource", "external_aws_cloudwatch_logs", "external_aws_cloudwatch_metrics", "external_elasticsearch_logs", "external_google_cloud_logging", "external_opensearch_logs", "flink", "flink_external_bigquery", "flink_external_kafka", "internal_connectivity", "jolokia", "kafka_connect", "kafka_logs", "kafka_mirrormaker", "logs", "m3aggregator", "m3coordinator", "metrics", "opensearch_cross_cluster_replication", "opensearch_cross_cluster_search", "prometheus", "read_replica", "rsyslog", "schema_registry_proxy", "stresstester", "thanoscompactor", "thanosquery", "thanosstore", "vector", "vmalert"}
+	return []string{"alertmanager", "autoscaler", "caching", "cassandra_cross_service_cluster", "clickhouse_credentials", "clickhouse_kafka", "clickhouse_postgresql", "dashboard", "datadog", "datasource", "external_aws_cloudwatch_logs", "external_aws_cloudwatch_metrics", "external_elasticsearch_logs", "external_google_cloud_logging", "external_opensearch_logs", "flink", "flink_external_bigquery", "flink_external_kafka", "internal_connectivity", "jolokia", "kafka_connect", "kafka_connect_postgresql", "kafka_logs", "kafka_mirrormaker", "logs", "m3aggregator", "m3coordinator", "metrics", "opensearch_cross_cluster_replication", "opensearch_cross_cluster_search", "prometheus", "read_replica", "rsyslog", "schema_registry_proxy", "stresstester", "thanoscompactor", "thanosquery", "thanosstore", "vector", "vmalert"}
 }
 
 type IntegrationTypeOut struct {
@@ -317,6 +332,20 @@ type IntegrationTypeOut struct {
 	SourceServiceTypes []string       `json:"source_service_types"`
 	UserConfigSchema   map[string]any `json:"user_config_schema"`
 }
+type LikelyErrorCauseType string
+
+const (
+	LikelyErrorCauseTypeNull        LikelyErrorCauseType = "null"
+	LikelyErrorCauseTypeDestination LikelyErrorCauseType = "destination"
+	LikelyErrorCauseTypeIntegration LikelyErrorCauseType = "integration"
+	LikelyErrorCauseTypeSource      LikelyErrorCauseType = "source"
+	LikelyErrorCauseTypeUnknown     LikelyErrorCauseType = "unknown"
+)
+
+func LikelyErrorCauseTypeChoices() []string {
+	return []string{"null", "destination", "integration", "source", "unknown"}
+}
+
 type ServiceIntegrationCreateIn struct {
 	DestEndpointId   string          `json:"dest_endpoint_id,omitempty"`
 	DestProject      string          `json:"dest_project,omitempty"`
@@ -355,21 +384,21 @@ type ServiceIntegrationEndpointCreateOut struct {
 	EndpointConfig map[string]any `json:"endpoint_config"`
 	EndpointId     string         `json:"endpoint_id"`
 	EndpointName   string         `json:"endpoint_name"`
-	EndpointType   string         `json:"endpoint_type"`
+	EndpointType   EndpointType   `json:"endpoint_type"`
 	UserConfig     map[string]any `json:"user_config"`
 }
 type ServiceIntegrationEndpointGetOut struct {
 	EndpointConfig map[string]any `json:"endpoint_config"`
 	EndpointId     string         `json:"endpoint_id"`
 	EndpointName   string         `json:"endpoint_name"`
-	EndpointType   string         `json:"endpoint_type"`
+	EndpointType   EndpointType   `json:"endpoint_type"`
 	UserConfig     map[string]any `json:"user_config"`
 }
 type ServiceIntegrationEndpointOut struct {
 	EndpointConfig map[string]any `json:"endpoint_config"`
 	EndpointId     string         `json:"endpoint_id"`
 	EndpointName   string         `json:"endpoint_name"`
-	EndpointType   string         `json:"endpoint_type"`
+	EndpointType   EndpointType   `json:"endpoint_type"`
 	UserConfig     map[string]any `json:"user_config"`
 }
 type ServiceIntegrationEndpointUpdateIn struct {
@@ -379,7 +408,7 @@ type ServiceIntegrationEndpointUpdateOut struct {
 	EndpointConfig map[string]any `json:"endpoint_config"`
 	EndpointId     string         `json:"endpoint_id"`
 	EndpointName   string         `json:"endpoint_name"`
-	EndpointType   string         `json:"endpoint_type"`
+	EndpointType   EndpointType   `json:"endpoint_type"`
 	UserConfig     map[string]any `json:"user_config"`
 }
 type ServiceIntegrationGetOut struct {
@@ -443,10 +472,10 @@ type ServiceIntegrationUpdateOut struct {
 	UserConfig           map[string]any        `json:"user_config,omitempty"`
 }
 type StateOut struct {
-	Errors           []string       `json:"errors"`
-	LikelyErrorCause string         `json:"likely_error_cause,omitempty"`
-	Nodes            map[string]any `json:"nodes"`
-	Status           string         `json:"status"`
+	Errors           []string              `json:"errors"`
+	LikelyErrorCause LikelyErrorCauseType  `json:"likely_error_cause,omitempty"`
+	Nodes            map[string]any        `json:"nodes"`
+	Status           IntegrationStatusType `json:"status"`
 }
 type serviceIntegrationCreateOut struct {
 	ServiceIntegration ServiceIntegrationCreateOut `json:"service_integration"`

--- a/handler/serviceuser/serviceuser.go
+++ b/handler/serviceuser/serviceuser.go
@@ -123,10 +123,10 @@ type AccessControlOut struct {
 	RedisAclKeys       []string `json:"redis_acl_keys,omitempty"`
 }
 type AclOut struct {
-	Id         string `json:"id,omitempty"`
-	Permission string `json:"permission"`
-	Topic      string `json:"topic"`
-	Username   string `json:"username"`
+	Id         string         `json:"id,omitempty"`
+	Permission PermissionType `json:"permission"`
+	Topic      string         `json:"topic"`
+	Username   string         `json:"username"`
 }
 type AdditionalRegionOut struct {
 	Cloud       string `json:"cloud"`
@@ -154,30 +154,97 @@ type BackupOut struct {
 	StorageLocation   string                `json:"storage_location,omitempty"`
 }
 type ComponentOut struct {
-	Component                 string `json:"component"`
-	Host                      string `json:"host"`
-	KafkaAuthenticationMethod string `json:"kafka_authentication_method,omitempty"`
-	Path                      string `json:"path,omitempty"`
-	Port                      int    `json:"port"`
-	PrivatelinkConnectionId   string `json:"privatelink_connection_id,omitempty"`
-	Route                     string `json:"route"`
-	Ssl                       *bool  `json:"ssl,omitempty"`
-	Usage                     string `json:"usage"`
+	Component                 string                        `json:"component"`
+	Host                      string                        `json:"host"`
+	KafkaAuthenticationMethod KafkaAuthenticationMethodType `json:"kafka_authentication_method,omitempty"`
+	Path                      string                        `json:"path,omitempty"`
+	Port                      int                           `json:"port"`
+	PrivatelinkConnectionId   string                        `json:"privatelink_connection_id,omitempty"`
+	Route                     RouteType                     `json:"route"`
+	Ssl                       *bool                         `json:"ssl,omitempty"`
+	Usage                     UsageType                     `json:"usage"`
 }
 type ConnectionPoolOut struct {
-	ConnectionUri string `json:"connection_uri"`
-	Database      string `json:"database"`
-	PoolMode      string `json:"pool_mode"`
-	PoolName      string `json:"pool_name"`
-	PoolSize      int    `json:"pool_size"`
-	Username      string `json:"username,omitempty"`
+	ConnectionUri string       `json:"connection_uri"`
+	Database      string       `json:"database"`
+	PoolMode      PoolModeType `json:"pool_mode"`
+	PoolName      string       `json:"pool_name"`
+	PoolSize      int          `json:"pool_size"`
+	Username      string       `json:"username,omitempty"`
 }
+type DowType string
+
+const (
+	DowTypeMonday    DowType = "monday"
+	DowTypeTuesday   DowType = "tuesday"
+	DowTypeWednesday DowType = "wednesday"
+	DowTypeThursday  DowType = "thursday"
+	DowTypeFriday    DowType = "friday"
+	DowTypeSaturday  DowType = "saturday"
+	DowTypeSunday    DowType = "sunday"
+	DowTypeNever     DowType = "never"
+)
+
+func DowTypeChoices() []string {
+	return []string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday", "never"}
+}
+
 type IntegrationStatusOut struct {
 	State          StateOut `json:"state"`
 	StatusUserDesc string   `json:"status_user_desc"`
 }
+type IntegrationStatusType string
+
+const (
+	IntegrationStatusTypeFailed   IntegrationStatusType = "failed"
+	IntegrationStatusTypeInactive IntegrationStatusType = "inactive"
+	IntegrationStatusTypeRunning  IntegrationStatusType = "running"
+	IntegrationStatusTypeStarting IntegrationStatusType = "starting"
+	IntegrationStatusTypeUnknown  IntegrationStatusType = "unknown"
+)
+
+func IntegrationStatusTypeChoices() []string {
+	return []string{"failed", "inactive", "running", "starting", "unknown"}
+}
+
+type KafkaAuthenticationMethodType string
+
+const (
+	KafkaAuthenticationMethodTypeCertificate KafkaAuthenticationMethodType = "certificate"
+	KafkaAuthenticationMethodTypeSasl        KafkaAuthenticationMethodType = "sasl"
+)
+
+func KafkaAuthenticationMethodTypeChoices() []string {
+	return []string{"certificate", "sasl"}
+}
+
+type LevelType string
+
+const (
+	LevelTypeNotice  LevelType = "notice"
+	LevelTypeWarning LevelType = "warning"
+)
+
+func LevelTypeChoices() []string {
+	return []string{"notice", "warning"}
+}
+
+type LikelyErrorCauseType string
+
+const (
+	LikelyErrorCauseTypeNull        LikelyErrorCauseType = "null"
+	LikelyErrorCauseTypeDestination LikelyErrorCauseType = "destination"
+	LikelyErrorCauseTypeIntegration LikelyErrorCauseType = "integration"
+	LikelyErrorCauseTypeSource      LikelyErrorCauseType = "source"
+	LikelyErrorCauseTypeUnknown     LikelyErrorCauseType = "unknown"
+)
+
+func LikelyErrorCauseTypeChoices() []string {
+	return []string{"null", "destination", "integration", "source", "unknown"}
+}
+
 type MaintenanceOut struct {
-	Dow     string      `json:"dow"`
+	Dow     DowType     `json:"dow"`
 	Time    string      `json:"time"`
 	Updates []UpdateOut `json:"updates"`
 }
@@ -191,10 +258,25 @@ type MetadataOut struct {
 type NodeStateOut struct {
 	Name            string              `json:"name"`
 	ProgressUpdates []ProgressUpdateOut `json:"progress_updates,omitempty"`
-	Role            string              `json:"role,omitempty"`
+	Role            RoleType            `json:"role,omitempty"`
 	Shard           *ShardOut           `json:"shard,omitempty"`
-	State           string              `json:"state"`
+	State           NodeStateType       `json:"state"`
 }
+type NodeStateType string
+
+const (
+	NodeStateTypeLeaving     NodeStateType = "leaving"
+	NodeStateTypeRunning     NodeStateType = "running"
+	NodeStateTypeSettingUpVm NodeStateType = "setting_up_vm"
+	NodeStateTypeSyncingData NodeStateType = "syncing_data"
+	NodeStateTypeTimingOut   NodeStateType = "timing_out"
+	NodeStateTypeUnknown     NodeStateType = "unknown"
+)
+
+func NodeStateTypeChoices() []string {
+	return []string{"leaving", "running", "setting_up_vm", "syncing_data", "timing_out", "unknown"}
+}
+
 type OperationType string
 
 const (
@@ -207,19 +289,93 @@ func OperationTypeChoices() []string {
 	return []string{"acknowledge-renewal", "reset-credentials", "set-access-control"}
 }
 
-type ProgressUpdateOut struct {
-	Completed bool   `json:"completed"`
-	Current   *int   `json:"current,omitempty"`
-	Max       *int   `json:"max,omitempty"`
-	Min       *int   `json:"min,omitempty"`
-	Phase     string `json:"phase"`
-	Unit      string `json:"unit,omitempty"`
+type PermissionType string
+
+const (
+	PermissionTypeAdmin     PermissionType = "admin"
+	PermissionTypeRead      PermissionType = "read"
+	PermissionTypeReadwrite PermissionType = "readwrite"
+	PermissionTypeWrite     PermissionType = "write"
+)
+
+func PermissionTypeChoices() []string {
+	return []string{"admin", "read", "readwrite", "write"}
 }
+
+type PermissionTypeAlt string
+
+const (
+	PermissionTypeAltSchemaRegistryRead  PermissionTypeAlt = "schema_registry_read"
+	PermissionTypeAltSchemaRegistryWrite PermissionTypeAlt = "schema_registry_write"
+)
+
+func PermissionTypeAltChoices() []string {
+	return []string{"schema_registry_read", "schema_registry_write"}
+}
+
+type PhaseType string
+
+const (
+	PhaseTypePrepare    PhaseType = "prepare"
+	PhaseTypeBasebackup PhaseType = "basebackup"
+	PhaseTypeStream     PhaseType = "stream"
+	PhaseTypeFinalize   PhaseType = "finalize"
+)
+
+func PhaseTypeChoices() []string {
+	return []string{"prepare", "basebackup", "stream", "finalize"}
+}
+
+type PoolModeType string
+
+const (
+	PoolModeTypeSession     PoolModeType = "session"
+	PoolModeTypeTransaction PoolModeType = "transaction"
+	PoolModeTypeStatement   PoolModeType = "statement"
+)
+
+func PoolModeTypeChoices() []string {
+	return []string{"session", "transaction", "statement"}
+}
+
+type ProgressUpdateOut struct {
+	Completed bool      `json:"completed"`
+	Current   *int      `json:"current,omitempty"`
+	Max       *int      `json:"max,omitempty"`
+	Min       *int      `json:"min,omitempty"`
+	Phase     PhaseType `json:"phase"`
+	Unit      UnitType  `json:"unit,omitempty"`
+}
+type RoleType string
+
+const (
+	RoleTypeMaster      RoleType = "master"
+	RoleTypeStandby     RoleType = "standby"
+	RoleTypeReadReplica RoleType = "read-replica"
+)
+
+func RoleTypeChoices() []string {
+	return []string{"master", "standby", "read-replica"}
+}
+
+type RouteType string
+
+const (
+	RouteTypeDynamic     RouteType = "dynamic"
+	RouteTypePublic      RouteType = "public"
+	RouteTypePrivate     RouteType = "private"
+	RouteTypePrivatelink RouteType = "privatelink"
+)
+
+func RouteTypeChoices() []string {
+	return []string{"dynamic", "public", "private", "privatelink"}
+}
+
 type SchemaRegistryAclOut struct {
-	Id         string `json:"id,omitempty"`
-	Permission string `json:"permission"`
-	Resource   string `json:"resource"`
-	Username   string `json:"username"`
+	Id         string            `json:"id,omitempty"`
+	Permission PermissionTypeAlt `json:"permission"`
+	Resource   string            `json:"resource"`
+	Username   string            `json:"username"`
 }
 type ServiceIntegrationOut struct {
 	Active               bool                  `json:"active"`
@@ -241,26 +397,50 @@ type ServiceIntegrationOut struct {
 	UserConfig           map[string]any        `json:"user_config,omitempty"`
 }
 type ServiceNotificationOut struct {
-	Level    string      `json:"level"`
-	Message  string      `json:"message"`
-	Metadata MetadataOut `json:"metadata"`
-	Type     string      `json:"type"`
+	Level    LevelType               `json:"level"`
+	Message  string                  `json:"message"`
+	Metadata MetadataOut             `json:"metadata"`
+	Type     ServiceNotificationType `json:"type"`
 }
+type ServiceNotificationType string
+
+const (
+	ServiceNotificationTypeServiceEndOfLife         ServiceNotificationType = "service_end_of_life"
+	ServiceNotificationTypeServicePoweredOffRemoval ServiceNotificationType = "service_powered_off_removal"
+)
+
+func ServiceNotificationTypeChoices() []string {
+	return []string{"service_end_of_life", "service_powered_off_removal"}
+}
+
+type ServiceStateType string
+
+const (
+	ServiceStateTypePoweroff    ServiceStateType = "POWEROFF"
+	ServiceStateTypeRebalancing ServiceStateType = "REBALANCING"
+	ServiceStateTypeRebuilding  ServiceStateType = "REBUILDING"
+	ServiceStateTypeRunning     ServiceStateType = "RUNNING"
+)
+
+func ServiceStateTypeChoices() []string {
+	return []string{"POWEROFF", "REBALANCING", "REBUILDING", "RUNNING"}
+}
+
 type ServiceUserCreateIn struct {
 	AccessControl  *AccessControlIn   `json:"access_control,omitempty"`
 	Authentication AuthenticationType `json:"authentication,omitempty"`
 	Username       string             `json:"username"`
 }
 type ServiceUserCreateOut struct {
-	AccessCert                    string            `json:"access_cert,omitempty"`
-	AccessCertNotValidAfterTime   *time.Time        `json:"access_cert_not_valid_after_time,omitempty"`
-	AccessControl                 *AccessControlOut `json:"access_control,omitempty"`
-	AccessKey                     string            `json:"access_key,omitempty"`
-	Authentication                string            `json:"authentication,omitempty"`
-	ExpiringCertNotValidAfterTime *time.Time        `json:"expiring_cert_not_valid_after_time,omitempty"`
-	Password                      string            `json:"password"`
-	Type                          string            `json:"type"`
-	Username                      string            `json:"username"`
+	AccessCert                    string             `json:"access_cert,omitempty"`
+	AccessCertNotValidAfterTime   *time.Time         `json:"access_cert_not_valid_after_time,omitempty"`
+	AccessControl                 *AccessControlOut  `json:"access_control,omitempty"`
+	AccessKey                     string             `json:"access_key,omitempty"`
+	Authentication                AuthenticationType `json:"authentication,omitempty"`
+	ExpiringCertNotValidAfterTime *time.Time         `json:"expiring_cert_not_valid_after_time,omitempty"`
+	Password                      string             `json:"password"`
+	Type                          string             `json:"type"`
+	Username                      string             `json:"username"`
 }
 type ServiceUserCredentialsModifyIn struct {
 	AccessControl  *AccessControlIn   `json:"access_control,omitempty"`
@@ -297,7 +477,7 @@ type ServiceUserCredentialsModifyOut struct {
 	ServiceTypeDescription string                   `json:"service_type_description,omitempty"`
 	ServiceUri             string                   `json:"service_uri"`
 	ServiceUriParams       map[string]any           `json:"service_uri_params,omitempty"`
-	State                  string                   `json:"state"`
+	State                  ServiceStateType         `json:"state"`
 	Tags                   map[string]string        `json:"tags,omitempty"`
 	TechEmails             []TechEmailOut           `json:"tech_emails,omitempty"`
 	TerminationProtection  bool                     `json:"termination_protection"`
@@ -335,7 +515,7 @@ type ServiceUserCredentialsResetOut struct {
 	ServiceTypeDescription string                   `json:"service_type_description,omitempty"`
 	ServiceUri             string                   `json:"service_uri"`
 	ServiceUriParams       map[string]any           `json:"service_uri_params,omitempty"`
-	State                  string                   `json:"state"`
+	State                  ServiceStateType         `json:"state"`
 	Tags                   map[string]string        `json:"tags,omitempty"`
 	TechEmails             []TechEmailOut           `json:"tech_emails,omitempty"`
 	TerminationProtection  bool                     `json:"termination_protection"`
@@ -345,55 +525,91 @@ type ServiceUserCredentialsResetOut struct {
 	Users                  []UserOut                `json:"users,omitempty"`
 }
 type ServiceUserGetOut struct {
-	AccessCert                    string            `json:"access_cert,omitempty"`
-	AccessCertNotValidAfterTime   *time.Time        `json:"access_cert_not_valid_after_time,omitempty"`
-	AccessControl                 *AccessControlOut `json:"access_control,omitempty"`
-	AccessKey                     string            `json:"access_key,omitempty"`
-	Authentication                string            `json:"authentication,omitempty"`
-	ExpiringCertNotValidAfterTime *time.Time        `json:"expiring_cert_not_valid_after_time,omitempty"`
-	Password                      string            `json:"password"`
-	Type                          string            `json:"type"`
-	Username                      string            `json:"username"`
+	AccessCert                    string             `json:"access_cert,omitempty"`
+	AccessCertNotValidAfterTime   *time.Time         `json:"access_cert_not_valid_after_time,omitempty"`
+	AccessControl                 *AccessControlOut  `json:"access_control,omitempty"`
+	AccessKey                     string             `json:"access_key,omitempty"`
+	Authentication                AuthenticationType `json:"authentication,omitempty"`
+	ExpiringCertNotValidAfterTime *time.Time         `json:"expiring_cert_not_valid_after_time,omitempty"`
+	Password                      string             `json:"password"`
+	Type                          string             `json:"type"`
+	Username                      string             `json:"username"`
 }
 type ShardOut struct {
 	Name     string `json:"name,omitempty"`
 	Position *int   `json:"position,omitempty"`
 }
 type StateOut struct {
-	Errors           []string       `json:"errors"`
-	LikelyErrorCause string         `json:"likely_error_cause,omitempty"`
-	Nodes            map[string]any `json:"nodes"`
-	Status           string         `json:"status"`
+	Errors           []string              `json:"errors"`
+	LikelyErrorCause LikelyErrorCauseType  `json:"likely_error_cause,omitempty"`
+	Nodes            map[string]any        `json:"nodes"`
+	Status           IntegrationStatusType `json:"status"`
 }
 type TechEmailOut struct {
 	Email string `json:"email"`
 }
 type TopicOut struct {
-	CleanupPolicy     string `json:"cleanup_policy"`
-	MinInsyncReplicas int    `json:"min_insync_replicas"`
-	Partitions        int    `json:"partitions"`
-	Replication       int    `json:"replication"`
-	RetentionBytes    int    `json:"retention_bytes"`
-	RetentionHours    int    `json:"retention_hours"`
-	State             string `json:"state,omitempty"`
-	TopicName         string `json:"topic_name"`
+	CleanupPolicy     string         `json:"cleanup_policy"`
+	MinInsyncReplicas int            `json:"min_insync_replicas"`
+	Partitions        int            `json:"partitions"`
+	Replication       int            `json:"replication"`
+	RetentionBytes    int            `json:"retention_bytes"`
+	RetentionHours    int            `json:"retention_hours"`
+	State             TopicStateType `json:"state,omitempty"`
+	TopicName         string         `json:"topic_name"`
 }
+type TopicStateType string
+
+const (
+	TopicStateTypeActive      TopicStateType = "ACTIVE"
+	TopicStateTypeConfiguring TopicStateType = "CONFIGURING"
+	TopicStateTypeDeleting    TopicStateType = "DELETING"
+)
+
+func TopicStateTypeChoices() []string {
+	return []string{"ACTIVE", "CONFIGURING", "DELETING"}
+}
+
+type UnitType string
+
+const (
+	UnitTypeBinlogs           UnitType = "binlogs"
+	UnitTypeBytesCompressed   UnitType = "bytes_compressed"
+	UnitTypeBytesUncompressed UnitType = "bytes_uncompressed"
+	UnitTypeWalLsn            UnitType = "wal_lsn"
+)
+
+func UnitTypeChoices() []string {
+	return []string{"binlogs", "bytes_compressed", "bytes_uncompressed", "wal_lsn"}
+}
+
 type UpdateOut struct {
 	Deadline    string     `json:"deadline,omitempty"`
 	Description string     `json:"description,omitempty"`
 	StartAfter  string     `json:"start_after,omitempty"`
 	StartAt     *time.Time `json:"start_at,omitempty"`
 }
+type UsageType string
+
+const (
+	UsageTypePrimary UsageType = "primary"
+	UsageTypeReplica UsageType = "replica"
+)
+
+func UsageTypeChoices() []string {
+	return []string{"primary", "replica"}
+}
+
 type UserOut struct {
-	AccessCert                    string            `json:"access_cert,omitempty"`
-	AccessCertNotValidAfterTime   *time.Time        `json:"access_cert_not_valid_after_time,omitempty"`
-	AccessControl                 *AccessControlOut `json:"access_control,omitempty"`
-	AccessKey                     string            `json:"access_key,omitempty"`
-	Authentication                string            `json:"authentication,omitempty"`
-	ExpiringCertNotValidAfterTime *time.Time        `json:"expiring_cert_not_valid_after_time,omitempty"`
-	Password                      string            `json:"password"`
-	Type                          string            `json:"type"`
-	Username                      string            `json:"username"`
+	AccessCert                    string             `json:"access_cert,omitempty"`
+	AccessCertNotValidAfterTime   *time.Time         `json:"access_cert_not_valid_after_time,omitempty"`
+	AccessControl                 *AccessControlOut  `json:"access_control,omitempty"`
+	AccessKey                     string             `json:"access_key,omitempty"`
+	Authentication                AuthenticationType `json:"authentication,omitempty"`
+	ExpiringCertNotValidAfterTime *time.Time         `json:"expiring_cert_not_valid_after_time,omitempty"`
+	Password                      string             `json:"password"`
+	Type                          string             `json:"type"`
+	Username                      string             `json:"username"`
 }
 type serviceUserCreateOut struct {
 	User ServiceUserCreateOut `json:"user"`

--- a/handler/staticip/staticip.go
+++ b/handler/staticip/staticip.go
@@ -153,56 +153,131 @@ type ProjectStaticIpassociateIn struct {
 	ServiceName string `json:"service_name"`
 }
 type ProjectStaticIpassociateOut struct {
-	CloudName             string `json:"cloud_name"`
-	IpAddress             string `json:"ip_address"`
-	ServiceName           string `json:"service_name"`
-	State                 string `json:"state"`
-	StaticIpAddressId     string `json:"static_ip_address_id"`
-	TerminationProtection bool   `json:"termination_protection"`
+	CloudName             string                            `json:"cloud_name"`
+	IpAddress             string                            `json:"ip_address"`
+	ServiceName           string                            `json:"service_name"`
+	State                 ProjectStaticIpassociateStateType `json:"state"`
+	StaticIpAddressId     string                            `json:"static_ip_address_id"`
+	TerminationProtection bool                              `json:"termination_protection"`
 }
+type ProjectStaticIpassociateStateType string
+
+const (
+	ProjectStaticIpassociateStateTypeCreating  ProjectStaticIpassociateStateType = "creating"
+	ProjectStaticIpassociateStateTypeCreated   ProjectStaticIpassociateStateType = "created"
+	ProjectStaticIpassociateStateTypeAvailable ProjectStaticIpassociateStateType = "available"
+	ProjectStaticIpassociateStateTypeAssigned  ProjectStaticIpassociateStateType = "assigned"
+	ProjectStaticIpassociateStateTypeDeleting  ProjectStaticIpassociateStateType = "deleting"
+	ProjectStaticIpassociateStateTypeDeleted   ProjectStaticIpassociateStateType = "deleted"
+)
+
+func ProjectStaticIpassociateStateTypeChoices() []string {
+	return []string{"creating", "created", "available", "assigned", "deleting", "deleted"}
+}
+
 type ProjectStaticIpdissociateOut struct {
-	CloudName             string `json:"cloud_name"`
-	IpAddress             string `json:"ip_address"`
-	ServiceName           string `json:"service_name"`
-	State                 string `json:"state"`
-	StaticIpAddressId     string `json:"static_ip_address_id"`
-	TerminationProtection bool   `json:"termination_protection"`
+	CloudName             string                             `json:"cloud_name"`
+	IpAddress             string                             `json:"ip_address"`
+	ServiceName           string                             `json:"service_name"`
+	State                 ProjectStaticIpdissociateStateType `json:"state"`
+	StaticIpAddressId     string                             `json:"static_ip_address_id"`
+	TerminationProtection bool                               `json:"termination_protection"`
 }
+type ProjectStaticIpdissociateStateType string
+
+const (
+	ProjectStaticIpdissociateStateTypeCreating  ProjectStaticIpdissociateStateType = "creating"
+	ProjectStaticIpdissociateStateTypeCreated   ProjectStaticIpdissociateStateType = "created"
+	ProjectStaticIpdissociateStateTypeAvailable ProjectStaticIpdissociateStateType = "available"
+	ProjectStaticIpdissociateStateTypeAssigned  ProjectStaticIpdissociateStateType = "assigned"
+	ProjectStaticIpdissociateStateTypeDeleting  ProjectStaticIpdissociateStateType = "deleting"
+	ProjectStaticIpdissociateStateTypeDeleted   ProjectStaticIpdissociateStateType = "deleted"
+)
+
+func ProjectStaticIpdissociateStateTypeChoices() []string {
+	return []string{"creating", "created", "available", "assigned", "deleting", "deleted"}
+}
+
 type ProjectStaticIppatchIn struct {
 	TerminationProtection *bool `json:"termination_protection,omitempty"`
 }
 type ProjectStaticIppatchOut struct {
-	CloudName             string `json:"cloud_name"`
-	IpAddress             string `json:"ip_address"`
-	ServiceName           string `json:"service_name"`
-	State                 string `json:"state"`
-	StaticIpAddressId     string `json:"static_ip_address_id"`
-	TerminationProtection bool   `json:"termination_protection"`
+	CloudName             string                        `json:"cloud_name"`
+	IpAddress             string                        `json:"ip_address"`
+	ServiceName           string                        `json:"service_name"`
+	State                 ProjectStaticIppatchStateType `json:"state"`
+	StaticIpAddressId     string                        `json:"static_ip_address_id"`
+	TerminationProtection bool                          `json:"termination_protection"`
 }
+type ProjectStaticIppatchStateType string
+
+const (
+	ProjectStaticIppatchStateTypeCreating  ProjectStaticIppatchStateType = "creating"
+	ProjectStaticIppatchStateTypeCreated   ProjectStaticIppatchStateType = "created"
+	ProjectStaticIppatchStateTypeAvailable ProjectStaticIppatchStateType = "available"
+	ProjectStaticIppatchStateTypeAssigned  ProjectStaticIppatchStateType = "assigned"
+	ProjectStaticIppatchStateTypeDeleting  ProjectStaticIppatchStateType = "deleting"
+	ProjectStaticIppatchStateTypeDeleted   ProjectStaticIppatchStateType = "deleted"
+)
+
+func ProjectStaticIppatchStateTypeChoices() []string {
+	return []string{"creating", "created", "available", "assigned", "deleting", "deleted"}
+}
+
 type StaticIpAddressAvailabilityOut struct {
 	CloudName string `json:"cloud_name"`
 	PriceUsd  string `json:"price_usd"`
 }
 type StaticIpOut struct {
-	CloudName             string `json:"cloud_name"`
-	IpAddress             string `json:"ip_address"`
-	ServiceName           string `json:"service_name"`
-	State                 string `json:"state"`
-	StaticIpAddressId     string `json:"static_ip_address_id"`
-	TerminationProtection bool   `json:"termination_protection"`
+	CloudName             string            `json:"cloud_name"`
+	IpAddress             string            `json:"ip_address"`
+	ServiceName           string            `json:"service_name"`
+	State                 StaticIpStateType `json:"state"`
+	StaticIpAddressId     string            `json:"static_ip_address_id"`
+	TerminationProtection bool              `json:"termination_protection"`
 }
+type StaticIpStateType string
+
+const (
+	StaticIpStateTypeCreating  StaticIpStateType = "creating"
+	StaticIpStateTypeCreated   StaticIpStateType = "created"
+	StaticIpStateTypeAvailable StaticIpStateType = "available"
+	StaticIpStateTypeAssigned  StaticIpStateType = "assigned"
+	StaticIpStateTypeDeleting  StaticIpStateType = "deleting"
+	StaticIpStateTypeDeleted   StaticIpStateType = "deleted"
+)
+
+func StaticIpStateTypeChoices() []string {
+	return []string{"creating", "created", "available", "assigned", "deleting", "deleted"}
+}
+
 type StaticIpcreateIn struct {
 	CloudName             string `json:"cloud_name"`
 	TerminationProtection *bool  `json:"termination_protection,omitempty"`
 }
 type StaticIpcreateOut struct {
-	CloudName             string `json:"cloud_name"`
-	IpAddress             string `json:"ip_address"`
-	ServiceName           string `json:"service_name"`
-	State                 string `json:"state"`
-	StaticIpAddressId     string `json:"static_ip_address_id"`
-	TerminationProtection bool   `json:"termination_protection"`
+	CloudName             string                  `json:"cloud_name"`
+	IpAddress             string                  `json:"ip_address"`
+	ServiceName           string                  `json:"service_name"`
+	State                 StaticIpcreateStateType `json:"state"`
+	StaticIpAddressId     string                  `json:"static_ip_address_id"`
+	TerminationProtection bool                    `json:"termination_protection"`
 }
+type StaticIpcreateStateType string
+
+const (
+	StaticIpcreateStateTypeCreating  StaticIpcreateStateType = "creating"
+	StaticIpcreateStateTypeCreated   StaticIpcreateStateType = "created"
+	StaticIpcreateStateTypeAvailable StaticIpcreateStateType = "available"
+	StaticIpcreateStateTypeAssigned  StaticIpcreateStateType = "assigned"
+	StaticIpcreateStateTypeDeleting  StaticIpcreateStateType = "deleting"
+	StaticIpcreateStateTypeDeleted   StaticIpcreateStateType = "deleted"
+)
+
+func StaticIpcreateStateTypeChoices() []string {
+	return []string{"creating", "created", "available", "assigned", "deleting", "deleted"}
+}
+
 type projectStaticIpavailabilityListOut struct {
 	StaticIpAddressAvailability []StaticIpAddressAvailabilityOut `json:"static_ip_address_availability"`
 }

--- a/handler/user/user.go
+++ b/handler/user/user.go
@@ -477,20 +477,60 @@ type AccountInviteOut struct {
 	TeamName           string    `json:"team_name"`
 	UserEmail          string    `json:"user_email"`
 }
-type AuthenticationMethodOut struct {
-	AuthenticationMethodAccountId string    `json:"authentication_method_account_id"`
-	CreateTime                    time.Time `json:"create_time"`
-	CurrentlyActive               bool      `json:"currently_active"`
-	DeleteTime                    time.Time `json:"delete_time"`
-	LastUsedTime                  time.Time `json:"last_used_time"`
-	MethodId                      string    `json:"method_id"`
-	Name                          string    `json:"name,omitempty"`
-	PublicRemoteIdentity          string    `json:"public_remote_identity"`
-	RemoteProviderId              string    `json:"remote_provider_id"`
-	State                         string    `json:"state"`
-	UpdateTime                    time.Time `json:"update_time"`
-	UserEmail                     string    `json:"user_email"`
+type ActionType string
+
+const (
+	ActionTypeAzureOauth  ActionType = "azure_oauth"
+	ActionTypeGithubOauth ActionType = "github_oauth"
+	ActionTypeGoogleOauth ActionType = "google_oauth"
+	ActionTypeHasuraOauth ActionType = "hasura_oauth"
+	ActionTypePassword    ActionType = "password"
+	ActionTypeSaml        ActionType = "saml"
+	ActionTypeSignup      ActionType = "signup"
+)
+
+func ActionTypeChoices() []string {
+	return []string{"azure_oauth", "github_oauth", "google_oauth", "hasura_oauth", "password", "saml", "signup"}
 }
+
+type AnyType string
+
+const (
+	AnyTypeAdmin     AnyType = "admin"
+	AnyTypeDeveloper AnyType = "developer"
+	AnyTypeOperator  AnyType = "operator"
+	AnyTypeReadOnly  AnyType = "read_only"
+)
+
+func AnyTypeChoices() []string {
+	return []string{"admin", "developer", "operator", "read_only"}
+}
+
+type AuthenticationMethodOut struct {
+	AuthenticationMethodAccountId string                        `json:"authentication_method_account_id"`
+	CreateTime                    time.Time                     `json:"create_time"`
+	CurrentlyActive               bool                          `json:"currently_active"`
+	DeleteTime                    time.Time                     `json:"delete_time"`
+	LastUsedTime                  time.Time                     `json:"last_used_time"`
+	MethodId                      string                        `json:"method_id"`
+	Name                          string                        `json:"name,omitempty"`
+	PublicRemoteIdentity          string                        `json:"public_remote_identity"`
+	RemoteProviderId              string                        `json:"remote_provider_id"`
+	State                         AuthenticationMethodStateType `json:"state"`
+	UpdateTime                    time.Time                     `json:"update_time"`
+	UserEmail                     string                        `json:"user_email"`
+}
+type AuthenticationMethodStateType string
+
+const (
+	AuthenticationMethodStateTypeActive  AuthenticationMethodStateType = "active"
+	AuthenticationMethodStateTypeDeleted AuthenticationMethodStateType = "deleted"
+)
+
+func AuthenticationMethodStateTypeChoices() []string {
+	return []string{"active", "deleted"}
+}
+
 type CheckPasswordStrengthExistingUserIn struct {
 	NewPassword string `json:"new_password"`
 	OldPassword string `json:"old_password"`
@@ -520,8 +560,19 @@ type InvitationOut struct {
 	InvitingUserEmail string    `json:"inviting_user_email"`
 	ProjectName       string    `json:"project_name"`
 }
+type MethodType string
+
+const (
+	MethodTypePost MethodType = "POST"
+	MethodTypeGet  MethodType = "GET"
+)
+
+func MethodTypeChoices() []string {
+	return []string{"POST", "GET"}
+}
+
 type ProjectMembershipOut struct {
-	Any string `json:"ANY,omitempty"`
+	Any AnyType `json:"ANY,omitempty"`
 }
 type ProjectMembershipsOut struct {
 	Any []string `json:"ANY,omitempty"`
@@ -573,8 +624,8 @@ type UserAuthLoginOptionsIn struct {
 }
 type UserAuthLoginOptionsOut struct {
 	None        []map[string]any `json:"None,omitempty"`
-	Action      string           `json:"action"`
-	Method      string           `json:"method,omitempty"`
+	Action      ActionType       `json:"action"`
+	Method      MethodType       `json:"method,omitempty"`
 	Name        string           `json:"name,omitempty"`
 	RedirectUrl string           `json:"redirect_url,omitempty"`
 }

--- a/handler/vpc/vpc.go
+++ b/handler/vpc/vpc.go
@@ -202,18 +202,18 @@ type PeeringConnectionIn struct {
 	UserPeerNetworkCidrs *[]string `json:"user_peer_network_cidrs,omitempty"`
 }
 type PeeringConnectionOut struct {
-	CreateTime               time.Time    `json:"create_time"`
-	PeerAzureAppId           string       `json:"peer_azure_app_id"`
-	PeerAzureTenantId        string       `json:"peer_azure_tenant_id"`
-	PeerCloudAccount         string       `json:"peer_cloud_account"`
-	PeerRegion               string       `json:"peer_region,omitempty"`
-	PeerResourceGroup        string       `json:"peer_resource_group"`
-	PeerVpc                  string       `json:"peer_vpc"`
-	State                    string       `json:"state"`
-	StateInfo                StateInfoOut `json:"state_info"`
-	UpdateTime               time.Time    `json:"update_time"`
-	UserPeerNetworkCidrs     []string     `json:"user_peer_network_cidrs"`
-	VpcPeeringConnectionType string       `json:"vpc_peering_connection_type"`
+	CreateTime               time.Time                     `json:"create_time"`
+	PeerAzureAppId           string                        `json:"peer_azure_app_id"`
+	PeerAzureTenantId        string                        `json:"peer_azure_tenant_id"`
+	PeerCloudAccount         string                        `json:"peer_cloud_account"`
+	PeerRegion               string                        `json:"peer_region,omitempty"`
+	PeerResourceGroup        string                        `json:"peer_resource_group"`
+	PeerVpc                  string                        `json:"peer_vpc"`
+	State                    VpcPeeringConnectionStateType `json:"state"`
+	StateInfo                StateInfoOut                  `json:"state_info"`
+	UpdateTime               time.Time                     `json:"update_time"`
+	UserPeerNetworkCidrs     []string                      `json:"user_peer_network_cidrs"`
+	VpcPeeringConnectionType VpcPeeringConnectionType      `json:"vpc_peering_connection_type"`
 }
 type StateInfoOut struct {
 	Message  string       `json:"message"`
@@ -232,7 +232,7 @@ type VpcCreateOut struct {
 	PeeringConnections                 []PeeringConnectionOut `json:"peering_connections"`
 	PendingBuildOnlyPeeringConnections string                 `json:"pending_build_only_peering_connections,omitempty"`
 	ProjectVpcId                       string                 `json:"project_vpc_id"`
-	State                              string                 `json:"state"`
+	State                              VpcStateType           `json:"state"`
 	UpdateTime                         time.Time              `json:"update_time"`
 }
 type VpcDeleteOut struct {
@@ -242,7 +242,7 @@ type VpcDeleteOut struct {
 	PeeringConnections                 []PeeringConnectionOut `json:"peering_connections"`
 	PendingBuildOnlyPeeringConnections string                 `json:"pending_build_only_peering_connections,omitempty"`
 	ProjectVpcId                       string                 `json:"project_vpc_id"`
-	State                              string                 `json:"state"`
+	State                              VpcStateType           `json:"state"`
 	UpdateTime                         time.Time              `json:"update_time"`
 }
 type VpcGetOut struct {
@@ -252,16 +252,16 @@ type VpcGetOut struct {
 	PeeringConnections                 []PeeringConnectionOut `json:"peering_connections"`
 	PendingBuildOnlyPeeringConnections string                 `json:"pending_build_only_peering_connections,omitempty"`
 	ProjectVpcId                       string                 `json:"project_vpc_id"`
-	State                              string                 `json:"state"`
+	State                              VpcStateType           `json:"state"`
 	UpdateTime                         time.Time              `json:"update_time"`
 }
 type VpcOut struct {
-	CloudName    string    `json:"cloud_name"`
-	CreateTime   time.Time `json:"create_time"`
-	NetworkCidr  string    `json:"network_cidr"`
-	ProjectVpcId string    `json:"project_vpc_id"`
-	State        string    `json:"state"`
-	UpdateTime   time.Time `json:"update_time"`
+	CloudName    string       `json:"cloud_name"`
+	CreateTime   time.Time    `json:"create_time"`
+	NetworkCidr  string       `json:"network_cidr"`
+	ProjectVpcId string       `json:"project_vpc_id"`
+	State        VpcStateType `json:"state"`
+	UpdateTime   time.Time    `json:"update_time"`
 }
 type VpcPeeringConnectionCreateIn struct {
 	PeerAzureAppId       string    `json:"peer_azure_app_id,omitempty"`
@@ -273,82 +273,152 @@ type VpcPeeringConnectionCreateIn struct {
 	UserPeerNetworkCidrs *[]string `json:"user_peer_network_cidrs,omitempty"`
 }
 type VpcPeeringConnectionCreateOut struct {
-	CreateTime               time.Time    `json:"create_time"`
-	PeerAzureAppId           string       `json:"peer_azure_app_id"`
-	PeerAzureTenantId        string       `json:"peer_azure_tenant_id"`
-	PeerCloudAccount         string       `json:"peer_cloud_account"`
-	PeerRegion               string       `json:"peer_region,omitempty"`
-	PeerResourceGroup        string       `json:"peer_resource_group"`
-	PeerVpc                  string       `json:"peer_vpc"`
-	State                    string       `json:"state"`
-	StateInfo                StateInfoOut `json:"state_info"`
-	UpdateTime               time.Time    `json:"update_time"`
-	UserPeerNetworkCidrs     []string     `json:"user_peer_network_cidrs"`
-	VpcPeeringConnectionType string       `json:"vpc_peering_connection_type"`
+	CreateTime               time.Time                     `json:"create_time"`
+	PeerAzureAppId           string                        `json:"peer_azure_app_id"`
+	PeerAzureTenantId        string                        `json:"peer_azure_tenant_id"`
+	PeerCloudAccount         string                        `json:"peer_cloud_account"`
+	PeerRegion               string                        `json:"peer_region,omitempty"`
+	PeerResourceGroup        string                        `json:"peer_resource_group"`
+	PeerVpc                  string                        `json:"peer_vpc"`
+	State                    VpcPeeringConnectionStateType `json:"state"`
+	StateInfo                StateInfoOut                  `json:"state_info"`
+	UpdateTime               time.Time                     `json:"update_time"`
+	UserPeerNetworkCidrs     []string                      `json:"user_peer_network_cidrs"`
+	VpcPeeringConnectionType VpcPeeringConnectionType      `json:"vpc_peering_connection_type"`
 }
 type VpcPeeringConnectionDeleteOut struct {
-	CreateTime               time.Time    `json:"create_time"`
-	PeerAzureAppId           string       `json:"peer_azure_app_id"`
-	PeerAzureTenantId        string       `json:"peer_azure_tenant_id"`
-	PeerCloudAccount         string       `json:"peer_cloud_account"`
-	PeerRegion               string       `json:"peer_region,omitempty"`
-	PeerResourceGroup        string       `json:"peer_resource_group"`
-	PeerVpc                  string       `json:"peer_vpc"`
-	State                    string       `json:"state"`
-	StateInfo                StateInfoOut `json:"state_info"`
-	UpdateTime               time.Time    `json:"update_time"`
-	UserPeerNetworkCidrs     []string     `json:"user_peer_network_cidrs"`
-	VpcPeeringConnectionType string       `json:"vpc_peering_connection_type"`
+	CreateTime               time.Time                     `json:"create_time"`
+	PeerAzureAppId           string                        `json:"peer_azure_app_id"`
+	PeerAzureTenantId        string                        `json:"peer_azure_tenant_id"`
+	PeerCloudAccount         string                        `json:"peer_cloud_account"`
+	PeerRegion               string                        `json:"peer_region,omitempty"`
+	PeerResourceGroup        string                        `json:"peer_resource_group"`
+	PeerVpc                  string                        `json:"peer_vpc"`
+	State                    VpcPeeringConnectionStateType `json:"state"`
+	StateInfo                StateInfoOut                  `json:"state_info"`
+	UpdateTime               time.Time                     `json:"update_time"`
+	UserPeerNetworkCidrs     []string                      `json:"user_peer_network_cidrs"`
+	VpcPeeringConnectionType VpcPeeringConnectionType      `json:"vpc_peering_connection_type"`
 }
+type VpcPeeringConnectionStateType string
+
+const (
+	VpcPeeringConnectionStateTypeActive                VpcPeeringConnectionStateType = "ACTIVE"
+	VpcPeeringConnectionStateTypeApproved              VpcPeeringConnectionStateType = "APPROVED"
+	VpcPeeringConnectionStateTypeApprovedPeerRequested VpcPeeringConnectionStateType = "APPROVED_PEER_REQUESTED"
+	VpcPeeringConnectionStateTypeDeleted               VpcPeeringConnectionStateType = "DELETED"
+	VpcPeeringConnectionStateTypeDeletedByPeer         VpcPeeringConnectionStateType = "DELETED_BY_PEER"
+	VpcPeeringConnectionStateTypeDeleting              VpcPeeringConnectionStateType = "DELETING"
+	VpcPeeringConnectionStateTypeError                 VpcPeeringConnectionStateType = "ERROR"
+	VpcPeeringConnectionStateTypeInvalidSpecification  VpcPeeringConnectionStateType = "INVALID_SPECIFICATION"
+	VpcPeeringConnectionStateTypePendingPeer           VpcPeeringConnectionStateType = "PENDING_PEER"
+	VpcPeeringConnectionStateTypeRejectedByPeer        VpcPeeringConnectionStateType = "REJECTED_BY_PEER"
+)
+
+func VpcPeeringConnectionStateTypeChoices() []string {
+	return []string{"ACTIVE", "APPROVED", "APPROVED_PEER_REQUESTED", "DELETED", "DELETED_BY_PEER", "DELETING", "ERROR", "INVALID_SPECIFICATION", "PENDING_PEER", "REJECTED_BY_PEER"}
+}
+
+type VpcPeeringConnectionStateTypeAlt string
+
+const (
+	VpcPeeringConnectionStateTypeAltActive   VpcPeeringConnectionStateTypeAlt = "ACTIVE"
+	VpcPeeringConnectionStateTypeAltApproved VpcPeeringConnectionStateTypeAlt = "APPROVED"
+	VpcPeeringConnectionStateTypeAltDeleted  VpcPeeringConnectionStateTypeAlt = "DELETED"
+	VpcPeeringConnectionStateTypeAltDeleting VpcPeeringConnectionStateTypeAlt = "DELETING"
+)
+
+func VpcPeeringConnectionStateTypeAltChoices() []string {
+	return []string{"ACTIVE", "APPROVED", "DELETED", "DELETING"}
+}
+
+type VpcPeeringConnectionType string
+
+const (
+	VpcPeeringConnectionTypeAwsTgwVpcAttachment     VpcPeeringConnectionType = "aws-tgw-vpc-attachment"
+	VpcPeeringConnectionTypeAwsVpcPeeringConnection VpcPeeringConnectionType = "aws-vpc-peering-connection"
+	VpcPeeringConnectionTypeAzureVnetPeering        VpcPeeringConnectionType = "azure-vnet-peering"
+	VpcPeeringConnectionTypeGoogleVpcPeering        VpcPeeringConnectionType = "google-vpc-peering"
+	VpcPeeringConnectionTypeUpcloudVpcPeering       VpcPeeringConnectionType = "upcloud-vpc-peering"
+)
+
+func VpcPeeringConnectionTypeChoices() []string {
+	return []string{"aws-tgw-vpc-attachment", "aws-vpc-peering-connection", "azure-vnet-peering", "google-vpc-peering", "upcloud-vpc-peering"}
+}
+
 type VpcPeeringConnectionUpdateIn struct {
 	Add    *[]AddIn  `json:"add,omitempty"`
 	Delete *[]string `json:"delete,omitempty"`
 }
 type VpcPeeringConnectionUpdateOut struct {
-	CloudName                          string                 `json:"cloud_name"`
-	CreateTime                         time.Time              `json:"create_time"`
-	NetworkCidr                        string                 `json:"network_cidr"`
-	PeeringConnections                 []PeeringConnectionOut `json:"peering_connections"`
-	PendingBuildOnlyPeeringConnections string                 `json:"pending_build_only_peering_connections,omitempty"`
-	ProjectVpcId                       string                 `json:"project_vpc_id"`
-	State                              string                 `json:"state"`
-	UpdateTime                         time.Time              `json:"update_time"`
+	CloudName                          string                           `json:"cloud_name"`
+	CreateTime                         time.Time                        `json:"create_time"`
+	NetworkCidr                        string                           `json:"network_cidr"`
+	PeeringConnections                 []PeeringConnectionOut           `json:"peering_connections"`
+	PendingBuildOnlyPeeringConnections string                           `json:"pending_build_only_peering_connections,omitempty"`
+	ProjectVpcId                       string                           `json:"project_vpc_id"`
+	State                              VpcPeeringConnectionStateTypeAlt `json:"state"`
+	UpdateTime                         time.Time                        `json:"update_time"`
 }
 type VpcPeeringConnectionWithRegionDeleteOut struct {
-	CreateTime               time.Time    `json:"create_time"`
-	PeerAzureAppId           string       `json:"peer_azure_app_id"`
-	PeerAzureTenantId        string       `json:"peer_azure_tenant_id"`
-	PeerCloudAccount         string       `json:"peer_cloud_account"`
-	PeerRegion               string       `json:"peer_region,omitempty"`
-	PeerResourceGroup        string       `json:"peer_resource_group"`
-	PeerVpc                  string       `json:"peer_vpc"`
-	State                    string       `json:"state"`
-	StateInfo                StateInfoOut `json:"state_info"`
-	UpdateTime               time.Time    `json:"update_time"`
-	UserPeerNetworkCidrs     []string     `json:"user_peer_network_cidrs"`
-	VpcPeeringConnectionType string       `json:"vpc_peering_connection_type"`
+	CreateTime               time.Time                     `json:"create_time"`
+	PeerAzureAppId           string                        `json:"peer_azure_app_id"`
+	PeerAzureTenantId        string                        `json:"peer_azure_tenant_id"`
+	PeerCloudAccount         string                        `json:"peer_cloud_account"`
+	PeerRegion               string                        `json:"peer_region,omitempty"`
+	PeerResourceGroup        string                        `json:"peer_resource_group"`
+	PeerVpc                  string                        `json:"peer_vpc"`
+	State                    VpcPeeringConnectionStateType `json:"state"`
+	StateInfo                StateInfoOut                  `json:"state_info"`
+	UpdateTime               time.Time                     `json:"update_time"`
+	UserPeerNetworkCidrs     []string                      `json:"user_peer_network_cidrs"`
+	VpcPeeringConnectionType VpcPeeringConnectionType      `json:"vpc_peering_connection_type"`
 }
 type VpcPeeringConnectionWithResourceGroupDeleteOut struct {
-	CreateTime               time.Time    `json:"create_time"`
-	PeerAzureAppId           string       `json:"peer_azure_app_id"`
-	PeerAzureTenantId        string       `json:"peer_azure_tenant_id"`
-	PeerCloudAccount         string       `json:"peer_cloud_account"`
-	PeerRegion               string       `json:"peer_region,omitempty"`
-	PeerResourceGroup        string       `json:"peer_resource_group"`
-	PeerVpc                  string       `json:"peer_vpc"`
-	State                    string       `json:"state"`
-	StateInfo                StateInfoOut `json:"state_info"`
-	UpdateTime               time.Time    `json:"update_time"`
-	UserPeerNetworkCidrs     []string     `json:"user_peer_network_cidrs"`
-	VpcPeeringConnectionType string       `json:"vpc_peering_connection_type"`
+	CreateTime               time.Time                     `json:"create_time"`
+	PeerAzureAppId           string                        `json:"peer_azure_app_id"`
+	PeerAzureTenantId        string                        `json:"peer_azure_tenant_id"`
+	PeerCloudAccount         string                        `json:"peer_cloud_account"`
+	PeerRegion               string                        `json:"peer_region,omitempty"`
+	PeerResourceGroup        string                        `json:"peer_resource_group"`
+	PeerVpc                  string                        `json:"peer_vpc"`
+	State                    VpcPeeringConnectionStateType `json:"state"`
+	StateInfo                StateInfoOut                  `json:"state_info"`
+	UpdateTime               time.Time                     `json:"update_time"`
+	UserPeerNetworkCidrs     []string                      `json:"user_peer_network_cidrs"`
+	VpcPeeringConnectionType VpcPeeringConnectionType      `json:"vpc_peering_connection_type"`
 }
+type VpcStateType string
+
+const (
+	VpcStateTypeActive   VpcStateType = "ACTIVE"
+	VpcStateTypeApproved VpcStateType = "APPROVED"
+	VpcStateTypeDeleted  VpcStateType = "DELETED"
+	VpcStateTypeDeleting VpcStateType = "DELETING"
+)
+
+func VpcStateTypeChoices() []string {
+	return []string{"ACTIVE", "APPROVED", "DELETED", "DELETING"}
+}
+
 type WarningOut struct {
-	ConflictingAwsAccountId              string `json:"conflicting_aws_account_id,omitempty"`
-	ConflictingAwsVpcId                  string `json:"conflicting_aws_vpc_id,omitempty"`
-	ConflictingAwsVpcPeeringConnectionId string `json:"conflicting_aws_vpc_peering_connection_id,omitempty"`
-	Message                              string `json:"message"`
-	Type                                 string `json:"type"`
+	ConflictingAwsAccountId              string      `json:"conflicting_aws_account_id,omitempty"`
+	ConflictingAwsVpcId                  string      `json:"conflicting_aws_vpc_id,omitempty"`
+	ConflictingAwsVpcPeeringConnectionId string      `json:"conflicting_aws_vpc_peering_connection_id,omitempty"`
+	Message                              string      `json:"message"`
+	Type                                 WarningType `json:"type"`
 }
+type WarningType string
+
+const (
+	WarningTypeOverlappingPeerVpcIpRanges WarningType = "overlapping-peer-vpc-ip-ranges"
+	WarningTypeUpcloudPeeringInError      WarningType = "upcloud-peering-in-error"
+)
+
+func WarningTypeChoices() []string {
+	return []string{"overlapping-peer-vpc-ip-ranges", "upcloud-peering-in-error"}
+}
+
 type vpcListOut struct {
 	Vpcs []VpcOut `json:"vpcs"`
 }


### PR DESCRIPTION
Adds Out enum types to use them in comparisons, e.g.

```go
if s.Status == service.ServiceStateTypeRunning {
    ....
}
```