### PR TITLE
refactor: add IsNilOrNotFound, remove OmitNotFound

### DIFF
--- a/error.go
+++ b/error.go
@@ -34,12 +34,8 @@ func IsAlreadyExists(err error) bool {
 	return errors.As(err, &e) && strings.Contains(e.Message, "already exists") && e.Status == http.StatusConflict
 }
 
-// OmitNotFound sometimes 404 is expected, and not an error.
-// For instance, when a resource is deleted in a retry loop.
-func OmitNotFound(err error) error {
-	if IsNotFound(err) {
-		return nil
-	}
-
-	return err
+// IsNilOrNotFound returns true for nil and 404 error.
+// This check is quite often used for resource deletion when 404 is not an issue.
+func IsNilOrNotFound(err error) bool {
+	return err == nil || IsNotFound(err)
 }


### PR DESCRIPTION
Replaces `OmitNotFound` with `IsNilOrNotFound` because `OmitNotFound` still requires additional `nil` check.