### PR TITLE
feat!: support string pointers

### DIFF
--- a/generator/main.go
+++ b/generator/main.go
@@ -300,7 +300,7 @@ func exec() error {
 				// But for required scalars should be zero values
 				returnErr = jen.Return(jen.Nil(), jen.Err())
 
-				if rsp.required || rsp.Type == SchemaTypeString {
+				if rsp.required {
 					switch rsp.Type {
 					case SchemaTypeString:
 						returnErr = jen.Return(jen.Lit(""), jen.Err())

--- a/generator/models.go
+++ b/generator/models.go
@@ -361,11 +361,11 @@ func getType(s *Schema) *jen.Statement {
 		return jen.Id(s.CamelName)
 	case s.isScalar():
 		scalar := getScalarType(s)
-		if !s.required && s.Type != SchemaTypeString {
-			return jen.Op("*").Add(scalar)
+		if s.required {
+			return scalar
 		}
 
-		return scalar
+		return jen.Op("*").Add(scalar)
 	}
 
 	switch {

--- a/handler/account/account.go
+++ b/handler/account/account.go
@@ -286,14 +286,14 @@ type AccountAttachPaymentMethodOut struct {
 	ExpYear        int      `json:"exp_year"`
 	Last4          string   `json:"last4"`
 	Name           string   `json:"name"`
-	OrganizationId string   `json:"organization_id,omitempty"`
+	OrganizationId *string  `json:"organization_id,omitempty"`
 	Projects       []string `json:"projects"`
 }
 type AccountBillingGroupOut struct {
 	AccountId             string              `json:"account_id"`
 	AccountName           string              `json:"account_name"`
 	AddressLines          []string            `json:"address_lines"`
-	BillingAddress        string              `json:"billing_address,omitempty"`
+	BillingAddress        *string             `json:"billing_address,omitempty"`
 	BillingCurrency       BillingCurrencyType `json:"billing_currency"`
 	BillingEmails         []BillingEmailOut   `json:"billing_emails"`
 	BillingExtraText      string              `json:"billing_extra_text"`
@@ -313,9 +313,9 @@ type AccountBillingGroupOut struct {
 	ZipCode               string              `json:"zip_code"`
 }
 type AccountCreateIn struct {
-	AccountName           string `json:"account_name"`
-	ParentAccountId       string `json:"parent_account_id,omitempty"`
-	PrimaryBillingGroupId string `json:"primary_billing_group_id,omitempty"`
+	AccountName           string  `json:"account_name"`
+	ParentAccountId       *string `json:"parent_account_id,omitempty"`
+	PrimaryBillingGroupId *string `json:"primary_billing_group_id,omitempty"`
 }
 type AccountCreateOut struct {
 	AccessSource          AccessSourceType `json:"access_source,omitempty"`
@@ -327,10 +327,10 @@ type AccountCreateOut struct {
 	IsAccountMember       *bool            `json:"is_account_member,omitempty"`
 	IsAccountOwner        bool             `json:"is_account_owner"`
 	OrganizationId        string           `json:"organization_id"`
-	ParentAccountId       string           `json:"parent_account_id,omitempty"`
+	ParentAccountId       *string          `json:"parent_account_id,omitempty"`
 	PrimaryBillingGroupId string           `json:"primary_billing_group_id"`
 	RootAccountId         string           `json:"root_account_id"`
-	TenantId              string           `json:"tenant_id,omitempty"`
+	TenantId              *string          `json:"tenant_id,omitempty"`
 	UpdateTime            time.Time        `json:"update_time"`
 }
 type AccountGetOut struct {
@@ -343,10 +343,10 @@ type AccountGetOut struct {
 	IsAccountMember       *bool            `json:"is_account_member,omitempty"`
 	IsAccountOwner        bool             `json:"is_account_owner"`
 	OrganizationId        string           `json:"organization_id"`
-	ParentAccountId       string           `json:"parent_account_id,omitempty"`
+	ParentAccountId       *string          `json:"parent_account_id,omitempty"`
 	PrimaryBillingGroupId string           `json:"primary_billing_group_id"`
 	RootAccountId         string           `json:"root_account_id"`
-	TenantId              string           `json:"tenant_id,omitempty"`
+	TenantId              *string          `json:"tenant_id,omitempty"`
 	UpdateTime            time.Time        `json:"update_time"`
 }
 type AccountMoveIn struct {
@@ -362,10 +362,10 @@ type AccountMoveOut struct {
 	IsAccountMember       *bool            `json:"is_account_member,omitempty"`
 	IsAccountOwner        bool             `json:"is_account_owner"`
 	OrganizationId        string           `json:"organization_id"`
-	ParentAccountId       string           `json:"parent_account_id,omitempty"`
+	ParentAccountId       *string          `json:"parent_account_id,omitempty"`
 	PrimaryBillingGroupId string           `json:"primary_billing_group_id"`
 	RootAccountId         string           `json:"root_account_id"`
-	TenantId              string           `json:"tenant_id,omitempty"`
+	TenantId              *string          `json:"tenant_id,omitempty"`
 	UpdateTime            time.Time        `json:"update_time"`
 }
 type AccountOut struct {
@@ -378,10 +378,10 @@ type AccountOut struct {
 	IsAccountMember       *bool            `json:"is_account_member,omitempty"`
 	IsAccountOwner        bool             `json:"is_account_owner"`
 	OrganizationId        string           `json:"organization_id"`
-	ParentAccountId       string           `json:"parent_account_id,omitempty"`
+	ParentAccountId       *string          `json:"parent_account_id,omitempty"`
 	PrimaryBillingGroupId string           `json:"primary_billing_group_id"`
 	RootAccountId         string           `json:"root_account_id"`
-	TenantId              string           `json:"tenant_id,omitempty"`
+	TenantId              *string          `json:"tenant_id,omitempty"`
 	UpdateTime            time.Time        `json:"update_time"`
 }
 type AccountProjectsListOut struct {
@@ -389,8 +389,8 @@ type AccountProjectsListOut struct {
 	TotalProjectCount *int         `json:"total_project_count,omitempty"`
 }
 type AccountUpdateIn struct {
-	AccountName           string `json:"account_name,omitempty"`
-	PrimaryBillingGroupId string `json:"primary_billing_group_id,omitempty"`
+	AccountName           *string `json:"account_name,omitempty"`
+	PrimaryBillingGroupId *string `json:"primary_billing_group_id,omitempty"`
 }
 type AccountUpdateOut struct {
 	AccessSource          AccessSourceType `json:"access_source,omitempty"`
@@ -402,16 +402,16 @@ type AccountUpdateOut struct {
 	IsAccountMember       *bool            `json:"is_account_member,omitempty"`
 	IsAccountOwner        bool             `json:"is_account_owner"`
 	OrganizationId        string           `json:"organization_id"`
-	ParentAccountId       string           `json:"parent_account_id,omitempty"`
+	ParentAccountId       *string          `json:"parent_account_id,omitempty"`
 	PrimaryBillingGroupId string           `json:"primary_billing_group_id"`
 	RootAccountId         string           `json:"root_account_id"`
-	TenantId              string           `json:"tenant_id,omitempty"`
+	TenantId              *string          `json:"tenant_id,omitempty"`
 	UpdateTime            time.Time        `json:"update_time"`
 }
 type AccountUsersSearchIn struct {
 	Limit   *int        `json:"limit,omitempty"`
 	OrderBy OrderByType `json:"order_by,omitempty"`
-	Query   string      `json:"query,omitempty"`
+	Query   *string     `json:"query,omitempty"`
 }
 type BillingCurrencyType string
 
@@ -520,35 +520,35 @@ func PaymentMethodTypeChoices() []string {
 
 type ProjectOut struct {
 	AccountId             string                 `json:"account_id"`
-	AccountName           string                 `json:"account_name,omitempty"`
+	AccountName           *string                `json:"account_name,omitempty"`
 	AddressLines          []string               `json:"address_lines,omitempty"`
-	AvailableCredits      string                 `json:"available_credits,omitempty"`
+	AvailableCredits      *string                `json:"available_credits,omitempty"`
 	BillingAddress        string                 `json:"billing_address"`
 	BillingCurrency       BillingCurrencyType    `json:"billing_currency,omitempty"`
 	BillingEmails         []BillingEmailOut      `json:"billing_emails"`
-	BillingExtraText      string                 `json:"billing_extra_text,omitempty"`
+	BillingExtraText      *string                `json:"billing_extra_text,omitempty"`
 	BillingGroupId        string                 `json:"billing_group_id"`
 	BillingGroupName      string                 `json:"billing_group_name"`
 	CardInfo              *CardInfoOut           `json:"card_info,omitempty"`
-	City                  string                 `json:"city,omitempty"`
-	Company               string                 `json:"company,omitempty"`
+	City                  *string                `json:"city,omitempty"`
+	Company               *string                `json:"company,omitempty"`
 	Country               string                 `json:"country"`
 	CountryCode           string                 `json:"country_code"`
 	DefaultCloud          string                 `json:"default_cloud"`
 	EndOfLifeExtension    *EndOfLifeExtensionOut `json:"end_of_life_extension,omitempty"`
 	EstimatedBalance      string                 `json:"estimated_balance"`
-	EstimatedBalanceLocal string                 `json:"estimated_balance_local,omitempty"`
+	EstimatedBalanceLocal *string                `json:"estimated_balance_local,omitempty"`
 	Features              map[string]any         `json:"features,omitempty"`
 	OrganizationId        string                 `json:"organization_id"`
 	PaymentMethod         string                 `json:"payment_method"`
 	ProjectName           string                 `json:"project_name"`
-	State                 string                 `json:"state,omitempty"`
+	State                 *string                `json:"state,omitempty"`
 	Tags                  map[string]string      `json:"tags,omitempty"`
 	TechEmails            []TechEmailOut         `json:"tech_emails,omitempty"`
-	TenantId              string                 `json:"tenant_id,omitempty"`
+	TenantId              *string                `json:"tenant_id,omitempty"`
 	TrialExpirationTime   *time.Time             `json:"trial_expiration_time,omitempty"`
 	VatId                 string                 `json:"vat_id"`
-	ZipCode               string                 `json:"zip_code,omitempty"`
+	ZipCode               *string                `json:"zip_code,omitempty"`
 }
 type TechEmailOut struct {
 	Email string `json:"email"`
@@ -559,7 +559,7 @@ type UserOut struct {
 	UserId    string `json:"user_id"`
 }
 type UserProjectOut struct {
-	AccessType  string     `json:"access_type,omitempty"`
+	AccessType  *string    `json:"access_type,omitempty"`
 	AccountId   string     `json:"account_id"`
 	CreateTime  time.Time  `json:"create_time"`
 	MemberType  MemberType `json:"member_type"`

--- a/handler/accountauthentication/accountauthentication.go
+++ b/handler/accountauthentication/accountauthentication.go
@@ -112,17 +112,17 @@ type AccountAuthenticationMethodCreateIn struct {
 	AuthTokenMaxAgeSeconds           *int                       `json:"auth_token_max_age_seconds,omitempty"`
 	AuthenticationMethodName         string                     `json:"authentication_method_name"`
 	AuthenticationMethodType         AuthenticationMethodType   `json:"authentication_method_type"`
-	AutoJoinTeamId                   string                     `json:"auto_join_team_id,omitempty"`
-	AutoJoinUserGroupId              string                     `json:"auto_join_user_group_id,omitempty"`
+	AutoJoinTeamId                   *string                    `json:"auto_join_team_id,omitempty"`
+	AutoJoinUserGroupId              *string                    `json:"auto_join_user_group_id,omitempty"`
 	LinkedDomains                    *[]LinkedDomainIn          `json:"linked_domains,omitempty"`
 	SamlAssertionSignedEnabled       *bool                      `json:"saml_assertion_signed_enabled,omitempty"`
 	SamlAuthnRequestsSignedEnabled   *bool                      `json:"saml_authn_requests_signed_enabled,omitempty"`
-	SamlCertificate                  string                     `json:"saml_certificate,omitempty"`
+	SamlCertificate                  *string                    `json:"saml_certificate,omitempty"`
 	SamlDigestAlgorithm              SamlDigestAlgorithmType    `json:"saml_digest_algorithm,omitempty"`
-	SamlEntityId                     string                     `json:"saml_entity_id,omitempty"`
+	SamlEntityId                     *string                    `json:"saml_entity_id,omitempty"`
 	SamlFieldMapping                 *SamlFieldMappingIn        `json:"saml_field_mapping,omitempty"`
 	SamlIdpLoginAllowed              *bool                      `json:"saml_idp_login_allowed,omitempty"`
-	SamlIdpUrl                       string                     `json:"saml_idp_url,omitempty"`
+	SamlIdpUrl                       *string                    `json:"saml_idp_url,omitempty"`
 	SamlRequestedAuthnContextEnabled *bool                      `json:"saml_requested_authn_context_enabled,omitempty"`
 	SamlSignatureAlgorithm           SamlSignatureAlgorithmType `json:"saml_signature_algorithm,omitempty"`
 	SamlVariant                      SamlVariantType            `json:"saml_variant,omitempty"`
@@ -134,34 +134,34 @@ type AccountAuthenticationMethodCreateOut struct {
 	AuthTokenMaxAgeSeconds           *int                          `json:"auth_token_max_age_seconds,omitempty"`
 	AuthenticationMethodEnabled      bool                          `json:"authentication_method_enabled"`
 	AuthenticationMethodId           string                        `json:"authentication_method_id"`
-	AuthenticationMethodName         string                        `json:"authentication_method_name,omitempty"`
+	AuthenticationMethodName         *string                       `json:"authentication_method_name,omitempty"`
 	AuthenticationMethodType         AuthenticationMethodType      `json:"authentication_method_type"`
 	AutoJoinTeamId                   string                        `json:"auto_join_team_id"`
 	AutoJoinUserGroupId              string                        `json:"auto_join_user_group_id"`
 	CreateTime                       time.Time                     `json:"create_time"`
 	DeleteTime                       time.Time                     `json:"delete_time"`
-	OrganizationId                   string                        `json:"organization_id,omitempty"`
-	SamlAcsUrl                       string                        `json:"saml_acs_url,omitempty"`
+	OrganizationId                   *string                       `json:"organization_id,omitempty"`
+	SamlAcsUrl                       *string                       `json:"saml_acs_url,omitempty"`
 	SamlAssertionSignedEnabled       *bool                         `json:"saml_assertion_signed_enabled,omitempty"`
 	SamlAuthnRequestsSignedEnabled   *bool                         `json:"saml_authn_requests_signed_enabled,omitempty"`
 	SamlCert                         SamlCertType                  `json:"saml_cert,omitempty"`
-	SamlCertificate                  string                        `json:"saml_certificate,omitempty"`
-	SamlCertificateIssuer            string                        `json:"saml_certificate_issuer,omitempty"`
-	SamlCertificateNotValidAfter     string                        `json:"saml_certificate_not_valid_after,omitempty"`
-	SamlCertificateNotValidBefore    string                        `json:"saml_certificate_not_valid_before,omitempty"`
-	SamlCertificateSubject           string                        `json:"saml_certificate_subject,omitempty"`
+	SamlCertificate                  *string                       `json:"saml_certificate,omitempty"`
+	SamlCertificateIssuer            *string                       `json:"saml_certificate_issuer,omitempty"`
+	SamlCertificateNotValidAfter     *string                       `json:"saml_certificate_not_valid_after,omitempty"`
+	SamlCertificateNotValidBefore    *string                       `json:"saml_certificate_not_valid_before,omitempty"`
+	SamlCertificateSubject           *string                       `json:"saml_certificate_subject,omitempty"`
 	SamlDigestAlgorithm              SamlDigestAlgorithmType       `json:"saml_digest_algorithm,omitempty"`
-	SamlEntityId                     string                        `json:"saml_entity_id,omitempty"`
+	SamlEntityId                     *string                       `json:"saml_entity_id,omitempty"`
 	SamlFieldMapping                 *SamlFieldMappingOut          `json:"saml_field_mapping,omitempty"`
 	SamlIdpLoginAllowed              *bool                         `json:"saml_idp_login_allowed,omitempty"`
-	SamlIdpUrl                       string                        `json:"saml_idp_url,omitempty"`
-	SamlMetadataUrl                  string                        `json:"saml_metadata_url,omitempty"`
+	SamlIdpUrl                       *string                       `json:"saml_idp_url,omitempty"`
+	SamlMetadataUrl                  *string                       `json:"saml_metadata_url,omitempty"`
 	SamlRequestedAuthnContextEnabled *bool                         `json:"saml_requested_authn_context_enabled,omitempty"`
 	SamlSignatureAlgorithm           SamlSignatureAlgorithmType    `json:"saml_signature_algorithm,omitempty"`
-	SamlSpCertificate                string                        `json:"saml_sp_certificate,omitempty"`
+	SamlSpCertificate                *string                       `json:"saml_sp_certificate,omitempty"`
 	SamlVariant                      SamlVariantType               `json:"saml_variant,omitempty"`
 	ScimEnabled                      *bool                         `json:"scim_enabled,omitempty"`
-	ScimUrl                          string                        `json:"scim_url,omitempty"`
+	ScimUrl                          *string                       `json:"scim_url,omitempty"`
 	State                            AuthenticationMethodStateType `json:"state"`
 	UpdateTime                       time.Time                     `json:"update_time"`
 }
@@ -171,34 +171,34 @@ type AccountAuthenticationMethodGetOut struct {
 	AuthTokenMaxAgeSeconds           *int                          `json:"auth_token_max_age_seconds,omitempty"`
 	AuthenticationMethodEnabled      bool                          `json:"authentication_method_enabled"`
 	AuthenticationMethodId           string                        `json:"authentication_method_id"`
-	AuthenticationMethodName         string                        `json:"authentication_method_name,omitempty"`
+	AuthenticationMethodName         *string                       `json:"authentication_method_name,omitempty"`
 	AuthenticationMethodType         AuthenticationMethodType      `json:"authentication_method_type"`
 	AutoJoinTeamId                   string                        `json:"auto_join_team_id"`
 	AutoJoinUserGroupId              string                        `json:"auto_join_user_group_id"`
 	CreateTime                       time.Time                     `json:"create_time"`
 	DeleteTime                       time.Time                     `json:"delete_time"`
-	OrganizationId                   string                        `json:"organization_id,omitempty"`
-	SamlAcsUrl                       string                        `json:"saml_acs_url,omitempty"`
+	OrganizationId                   *string                       `json:"organization_id,omitempty"`
+	SamlAcsUrl                       *string                       `json:"saml_acs_url,omitempty"`
 	SamlAssertionSignedEnabled       *bool                         `json:"saml_assertion_signed_enabled,omitempty"`
 	SamlAuthnRequestsSignedEnabled   *bool                         `json:"saml_authn_requests_signed_enabled,omitempty"`
 	SamlCert                         SamlCertType                  `json:"saml_cert,omitempty"`
-	SamlCertificate                  string                        `json:"saml_certificate,omitempty"`
-	SamlCertificateIssuer            string                        `json:"saml_certificate_issuer,omitempty"`
-	SamlCertificateNotValidAfter     string                        `json:"saml_certificate_not_valid_after,omitempty"`
-	SamlCertificateNotValidBefore    string                        `json:"saml_certificate_not_valid_before,omitempty"`
-	SamlCertificateSubject           string                        `json:"saml_certificate_subject,omitempty"`
+	SamlCertificate                  *string                       `json:"saml_certificate,omitempty"`
+	SamlCertificateIssuer            *string                       `json:"saml_certificate_issuer,omitempty"`
+	SamlCertificateNotValidAfter     *string                       `json:"saml_certificate_not_valid_after,omitempty"`
+	SamlCertificateNotValidBefore    *string                       `json:"saml_certificate_not_valid_before,omitempty"`
+	SamlCertificateSubject           *string                       `json:"saml_certificate_subject,omitempty"`
 	SamlDigestAlgorithm              SamlDigestAlgorithmType       `json:"saml_digest_algorithm,omitempty"`
-	SamlEntityId                     string                        `json:"saml_entity_id,omitempty"`
+	SamlEntityId                     *string                       `json:"saml_entity_id,omitempty"`
 	SamlFieldMapping                 *SamlFieldMappingOut          `json:"saml_field_mapping,omitempty"`
 	SamlIdpLoginAllowed              *bool                         `json:"saml_idp_login_allowed,omitempty"`
-	SamlIdpUrl                       string                        `json:"saml_idp_url,omitempty"`
-	SamlMetadataUrl                  string                        `json:"saml_metadata_url,omitempty"`
+	SamlIdpUrl                       *string                       `json:"saml_idp_url,omitempty"`
+	SamlMetadataUrl                  *string                       `json:"saml_metadata_url,omitempty"`
 	SamlRequestedAuthnContextEnabled *bool                         `json:"saml_requested_authn_context_enabled,omitempty"`
 	SamlSignatureAlgorithm           SamlSignatureAlgorithmType    `json:"saml_signature_algorithm,omitempty"`
-	SamlSpCertificate                string                        `json:"saml_sp_certificate,omitempty"`
+	SamlSpCertificate                *string                       `json:"saml_sp_certificate,omitempty"`
 	SamlVariant                      SamlVariantType               `json:"saml_variant,omitempty"`
 	ScimEnabled                      *bool                         `json:"scim_enabled,omitempty"`
-	ScimUrl                          string                        `json:"scim_url,omitempty"`
+	ScimUrl                          *string                       `json:"scim_url,omitempty"`
 	State                            AuthenticationMethodStateType `json:"state"`
 	UpdateTime                       time.Time                     `json:"update_time"`
 }
@@ -206,17 +206,17 @@ type AccountAuthenticationMethodUpdateIn struct {
 	AuthTokenExtendWhenUsed          *bool                      `json:"auth_token_extend_when_used,omitempty"`
 	AuthTokenMaxAgeSeconds           *int                       `json:"auth_token_max_age_seconds,omitempty"`
 	AuthenticationMethodEnabled      *bool                      `json:"authentication_method_enabled,omitempty"`
-	AuthenticationMethodName         string                     `json:"authentication_method_name,omitempty"`
-	AutoJoinTeamId                   string                     `json:"auto_join_team_id,omitempty"`
-	AutoJoinUserGroupId              string                     `json:"auto_join_user_group_id,omitempty"`
+	AuthenticationMethodName         *string                    `json:"authentication_method_name,omitempty"`
+	AutoJoinTeamId                   *string                    `json:"auto_join_team_id,omitempty"`
+	AutoJoinUserGroupId              *string                    `json:"auto_join_user_group_id,omitempty"`
 	SamlAssertionSignedEnabled       *bool                      `json:"saml_assertion_signed_enabled,omitempty"`
 	SamlAuthnRequestsSignedEnabled   *bool                      `json:"saml_authn_requests_signed_enabled,omitempty"`
-	SamlCertificate                  string                     `json:"saml_certificate,omitempty"`
+	SamlCertificate                  *string                    `json:"saml_certificate,omitempty"`
 	SamlDigestAlgorithm              SamlDigestAlgorithmType    `json:"saml_digest_algorithm,omitempty"`
-	SamlEntityId                     string                     `json:"saml_entity_id,omitempty"`
+	SamlEntityId                     *string                    `json:"saml_entity_id,omitempty"`
 	SamlFieldMapping                 *SamlFieldMappingIn        `json:"saml_field_mapping,omitempty"`
 	SamlIdpLoginAllowed              *bool                      `json:"saml_idp_login_allowed,omitempty"`
-	SamlIdpUrl                       string                     `json:"saml_idp_url,omitempty"`
+	SamlIdpUrl                       *string                    `json:"saml_idp_url,omitempty"`
 	SamlRequestedAuthnContextEnabled *bool                      `json:"saml_requested_authn_context_enabled,omitempty"`
 	SamlSignatureAlgorithm           SamlSignatureAlgorithmType `json:"saml_signature_algorithm,omitempty"`
 	SamlVariant                      SamlVariantType            `json:"saml_variant,omitempty"`
@@ -228,34 +228,34 @@ type AccountAuthenticationMethodUpdateOut struct {
 	AuthTokenMaxAgeSeconds           *int                          `json:"auth_token_max_age_seconds,omitempty"`
 	AuthenticationMethodEnabled      bool                          `json:"authentication_method_enabled"`
 	AuthenticationMethodId           string                        `json:"authentication_method_id"`
-	AuthenticationMethodName         string                        `json:"authentication_method_name,omitempty"`
+	AuthenticationMethodName         *string                       `json:"authentication_method_name,omitempty"`
 	AuthenticationMethodType         AuthenticationMethodType      `json:"authentication_method_type"`
 	AutoJoinTeamId                   string                        `json:"auto_join_team_id"`
 	AutoJoinUserGroupId              string                        `json:"auto_join_user_group_id"`
 	CreateTime                       time.Time                     `json:"create_time"`
 	DeleteTime                       time.Time                     `json:"delete_time"`
-	OrganizationId                   string                        `json:"organization_id,omitempty"`
-	SamlAcsUrl                       string                        `json:"saml_acs_url,omitempty"`
+	OrganizationId                   *string                       `json:"organization_id,omitempty"`
+	SamlAcsUrl                       *string                       `json:"saml_acs_url,omitempty"`
 	SamlAssertionSignedEnabled       *bool                         `json:"saml_assertion_signed_enabled,omitempty"`
 	SamlAuthnRequestsSignedEnabled   *bool                         `json:"saml_authn_requests_signed_enabled,omitempty"`
 	SamlCert                         SamlCertType                  `json:"saml_cert,omitempty"`
-	SamlCertificate                  string                        `json:"saml_certificate,omitempty"`
-	SamlCertificateIssuer            string                        `json:"saml_certificate_issuer,omitempty"`
-	SamlCertificateNotValidAfter     string                        `json:"saml_certificate_not_valid_after,omitempty"`
-	SamlCertificateNotValidBefore    string                        `json:"saml_certificate_not_valid_before,omitempty"`
-	SamlCertificateSubject           string                        `json:"saml_certificate_subject,omitempty"`
+	SamlCertificate                  *string                       `json:"saml_certificate,omitempty"`
+	SamlCertificateIssuer            *string                       `json:"saml_certificate_issuer,omitempty"`
+	SamlCertificateNotValidAfter     *string                       `json:"saml_certificate_not_valid_after,omitempty"`
+	SamlCertificateNotValidBefore    *string                       `json:"saml_certificate_not_valid_before,omitempty"`
+	SamlCertificateSubject           *string                       `json:"saml_certificate_subject,omitempty"`
 	SamlDigestAlgorithm              SamlDigestAlgorithmType       `json:"saml_digest_algorithm,omitempty"`
-	SamlEntityId                     string                        `json:"saml_entity_id,omitempty"`
+	SamlEntityId                     *string                       `json:"saml_entity_id,omitempty"`
 	SamlFieldMapping                 *SamlFieldMappingOut          `json:"saml_field_mapping,omitempty"`
 	SamlIdpLoginAllowed              *bool                         `json:"saml_idp_login_allowed,omitempty"`
-	SamlIdpUrl                       string                        `json:"saml_idp_url,omitempty"`
-	SamlMetadataUrl                  string                        `json:"saml_metadata_url,omitempty"`
+	SamlIdpUrl                       *string                       `json:"saml_idp_url,omitempty"`
+	SamlMetadataUrl                  *string                       `json:"saml_metadata_url,omitempty"`
 	SamlRequestedAuthnContextEnabled *bool                         `json:"saml_requested_authn_context_enabled,omitempty"`
 	SamlSignatureAlgorithm           SamlSignatureAlgorithmType    `json:"saml_signature_algorithm,omitempty"`
-	SamlSpCertificate                string                        `json:"saml_sp_certificate,omitempty"`
+	SamlSpCertificate                *string                       `json:"saml_sp_certificate,omitempty"`
 	SamlVariant                      SamlVariantType               `json:"saml_variant,omitempty"`
 	ScimEnabled                      *bool                         `json:"scim_enabled,omitempty"`
-	ScimUrl                          string                        `json:"scim_url,omitempty"`
+	ScimUrl                          *string                       `json:"scim_url,omitempty"`
 	State                            AuthenticationMethodStateType `json:"state"`
 	UpdateTime                       time.Time                     `json:"update_time"`
 }
@@ -265,34 +265,34 @@ type AuthenticationMethodOut struct {
 	AuthTokenMaxAgeSeconds           *int                          `json:"auth_token_max_age_seconds,omitempty"`
 	AuthenticationMethodEnabled      bool                          `json:"authentication_method_enabled"`
 	AuthenticationMethodId           string                        `json:"authentication_method_id"`
-	AuthenticationMethodName         string                        `json:"authentication_method_name,omitempty"`
+	AuthenticationMethodName         *string                       `json:"authentication_method_name,omitempty"`
 	AuthenticationMethodType         AuthenticationMethodType      `json:"authentication_method_type"`
 	AutoJoinTeamId                   string                        `json:"auto_join_team_id"`
 	AutoJoinUserGroupId              string                        `json:"auto_join_user_group_id"`
 	CreateTime                       time.Time                     `json:"create_time"`
 	DeleteTime                       time.Time                     `json:"delete_time"`
-	OrganizationId                   string                        `json:"organization_id,omitempty"`
-	SamlAcsUrl                       string                        `json:"saml_acs_url,omitempty"`
+	OrganizationId                   *string                       `json:"organization_id,omitempty"`
+	SamlAcsUrl                       *string                       `json:"saml_acs_url,omitempty"`
 	SamlAssertionSignedEnabled       *bool                         `json:"saml_assertion_signed_enabled,omitempty"`
 	SamlAuthnRequestsSignedEnabled   *bool                         `json:"saml_authn_requests_signed_enabled,omitempty"`
 	SamlCert                         SamlCertType                  `json:"saml_cert,omitempty"`
-	SamlCertificate                  string                        `json:"saml_certificate,omitempty"`
-	SamlCertificateIssuer            string                        `json:"saml_certificate_issuer,omitempty"`
-	SamlCertificateNotValidAfter     string                        `json:"saml_certificate_not_valid_after,omitempty"`
-	SamlCertificateNotValidBefore    string                        `json:"saml_certificate_not_valid_before,omitempty"`
-	SamlCertificateSubject           string                        `json:"saml_certificate_subject,omitempty"`
+	SamlCertificate                  *string                       `json:"saml_certificate,omitempty"`
+	SamlCertificateIssuer            *string                       `json:"saml_certificate_issuer,omitempty"`
+	SamlCertificateNotValidAfter     *string                       `json:"saml_certificate_not_valid_after,omitempty"`
+	SamlCertificateNotValidBefore    *string                       `json:"saml_certificate_not_valid_before,omitempty"`
+	SamlCertificateSubject           *string                       `json:"saml_certificate_subject,omitempty"`
 	SamlDigestAlgorithm              SamlDigestAlgorithmType       `json:"saml_digest_algorithm,omitempty"`
-	SamlEntityId                     string                        `json:"saml_entity_id,omitempty"`
+	SamlEntityId                     *string                       `json:"saml_entity_id,omitempty"`
 	SamlFieldMapping                 *SamlFieldMappingOut          `json:"saml_field_mapping,omitempty"`
 	SamlIdpLoginAllowed              *bool                         `json:"saml_idp_login_allowed,omitempty"`
-	SamlIdpUrl                       string                        `json:"saml_idp_url,omitempty"`
-	SamlMetadataUrl                  string                        `json:"saml_metadata_url,omitempty"`
+	SamlIdpUrl                       *string                       `json:"saml_idp_url,omitempty"`
+	SamlMetadataUrl                  *string                       `json:"saml_metadata_url,omitempty"`
 	SamlRequestedAuthnContextEnabled *bool                         `json:"saml_requested_authn_context_enabled,omitempty"`
 	SamlSignatureAlgorithm           SamlSignatureAlgorithmType    `json:"saml_signature_algorithm,omitempty"`
-	SamlSpCertificate                string                        `json:"saml_sp_certificate,omitempty"`
+	SamlSpCertificate                *string                       `json:"saml_sp_certificate,omitempty"`
 	SamlVariant                      SamlVariantType               `json:"saml_variant,omitempty"`
 	ScimEnabled                      *bool                         `json:"scim_enabled,omitempty"`
-	ScimUrl                          string                        `json:"scim_url,omitempty"`
+	ScimUrl                          *string                       `json:"scim_url,omitempty"`
 	State                            AuthenticationMethodStateType `json:"state"`
 	UpdateTime                       time.Time                     `json:"update_time"`
 }
@@ -346,18 +346,18 @@ func SamlDigestAlgorithmTypeChoices() []string {
 }
 
 type SamlFieldMappingIn struct {
-	Email     string `json:"email,omitempty"`
-	FirstName string `json:"first_name,omitempty"`
-	Identity  string `json:"identity,omitempty"`
-	LastName  string `json:"last_name,omitempty"`
-	RealName  string `json:"real_name,omitempty"`
+	Email     *string `json:"email,omitempty"`
+	FirstName *string `json:"first_name,omitempty"`
+	Identity  *string `json:"identity,omitempty"`
+	LastName  *string `json:"last_name,omitempty"`
+	RealName  *string `json:"real_name,omitempty"`
 }
 type SamlFieldMappingOut struct {
-	Email     string `json:"email,omitempty"`
-	FirstName string `json:"first_name,omitempty"`
-	Identity  string `json:"identity,omitempty"`
-	LastName  string `json:"last_name,omitempty"`
-	RealName  string `json:"real_name,omitempty"`
+	Email     *string `json:"email,omitempty"`
+	FirstName *string `json:"first_name,omitempty"`
+	Identity  *string `json:"identity,omitempty"`
+	LastName  *string `json:"last_name,omitempty"`
+	RealName  *string `json:"real_name,omitempty"`
 }
 type SamlSignatureAlgorithmType string
 

--- a/handler/accountteam/accountteam.go
+++ b/handler/accountteam/accountteam.go
@@ -155,7 +155,7 @@ type AccountInviteOut struct {
 	UserEmail          string    `json:"user_email"`
 }
 type AccountTeamGetOut struct {
-	AccountId  string     `json:"account_id,omitempty"`
+	AccountId  *string    `json:"account_id,omitempty"`
 	CreateTime *time.Time `json:"create_time,omitempty"`
 	TeamId     string     `json:"team_id"`
 	TeamName   string     `json:"team_name"`
@@ -168,7 +168,7 @@ type AccountTeamUpdateIn struct {
 	TeamName string `json:"team_name"`
 }
 type AccountTeamUpdateOut struct {
-	AccountId  string     `json:"account_id,omitempty"`
+	AccountId  *string    `json:"account_id,omitempty"`
 	CreateTime *time.Time `json:"create_time,omitempty"`
 	TeamId     string     `json:"team_id"`
 	TeamName   string     `json:"team_name"`
@@ -179,7 +179,7 @@ type ProjectOut struct {
 	TeamType    TeamType `json:"team_type"`
 }
 type TeamOut struct {
-	AccountId  string     `json:"account_id,omitempty"`
+	AccountId  *string    `json:"account_id,omitempty"`
 	CreateTime *time.Time `json:"create_time,omitempty"`
 	TeamId     string     `json:"team_id"`
 	TeamName   string     `json:"team_name"`

--- a/handler/applicationuser/applicationuser.go
+++ b/handler/applicationuser/applicationuser.go
@@ -199,13 +199,13 @@ type TokenOut struct {
 	CreateTime                 time.Time  `json:"create_time"`
 	CreatedManually            bool       `json:"created_manually"`
 	CurrentlyActive            bool       `json:"currently_active"`
-	Description                string     `json:"description,omitempty"`
+	Description                *string    `json:"description,omitempty"`
 	ExpiryTime                 *time.Time `json:"expiry_time,omitempty"`
 	ExtendWhenUsed             *bool      `json:"extend_when_used,omitempty"`
-	LastIp                     string     `json:"last_ip,omitempty"`
+	LastIp                     *string    `json:"last_ip,omitempty"`
 	LastUsedTime               *time.Time `json:"last_used_time,omitempty"`
-	LastUserAgent              string     `json:"last_user_agent,omitempty"`
-	LastUserAgentHumanReadable string     `json:"last_user_agent_human_readable,omitempty"`
+	LastUserAgent              *string    `json:"last_user_agent,omitempty"`
+	LastUserAgentHumanReadable *string    `json:"last_user_agent_human_readable,omitempty"`
 	MaxAgeSeconds              *int       `json:"max_age_seconds,omitempty"`
 	Scopes                     []string   `json:"scopes,omitempty"`
 	TokenPrefix                string     `json:"token_prefix"`

--- a/handler/billinggroup/billinggroup.go
+++ b/handler/billinggroup/billinggroup.go
@@ -263,26 +263,26 @@ type BillingEmailOut struct {
 	Email string `json:"email"`
 }
 type BillingGroupCreateIn struct {
-	AccountId            string              `json:"account_id,omitempty"`
+	AccountId            *string             `json:"account_id,omitempty"`
 	AddressLines         *[]string           `json:"address_lines,omitempty"`
 	BillingCurrency      BillingCurrencyType `json:"billing_currency,omitempty"`
 	BillingEmails        *[]BillingEmailIn   `json:"billing_emails,omitempty"`
-	BillingExtraText     string              `json:"billing_extra_text,omitempty"`
+	BillingExtraText     *string             `json:"billing_extra_text,omitempty"`
 	BillingGroupName     string              `json:"billing_group_name"`
-	CardId               string              `json:"card_id,omitempty"`
-	City                 string              `json:"city,omitempty"`
-	Company              string              `json:"company,omitempty"`
-	CopyFromBillingGroup string              `json:"copy_from_billing_group,omitempty"`
-	CountryCode          string              `json:"country_code,omitempty"`
-	State                string              `json:"state,omitempty"`
-	VatId                string              `json:"vat_id,omitempty"`
-	ZipCode              string              `json:"zip_code,omitempty"`
+	CardId               *string             `json:"card_id,omitempty"`
+	City                 *string             `json:"city,omitempty"`
+	Company              *string             `json:"company,omitempty"`
+	CopyFromBillingGroup *string             `json:"copy_from_billing_group,omitempty"`
+	CountryCode          *string             `json:"country_code,omitempty"`
+	State                *string             `json:"state,omitempty"`
+	VatId                *string             `json:"vat_id,omitempty"`
+	ZipCode              *string             `json:"zip_code,omitempty"`
 }
 type BillingGroupCreateOut struct {
 	AccountId             string              `json:"account_id"`
 	AccountName           string              `json:"account_name"`
 	AddressLines          []string            `json:"address_lines"`
-	BillingAddress        string              `json:"billing_address,omitempty"`
+	BillingAddress        *string             `json:"billing_address,omitempty"`
 	BillingCurrency       BillingCurrencyType `json:"billing_currency"`
 	BillingEmails         []BillingEmailOut   `json:"billing_emails"`
 	BillingExtraText      string              `json:"billing_extra_text"`
@@ -305,18 +305,18 @@ type BillingGroupCreditsClaimIn struct {
 	Code string `json:"code"`
 }
 type BillingGroupCreditsClaimOut struct {
-	Code           string     `json:"code,omitempty"`
+	Code           *string    `json:"code,omitempty"`
 	ExpireTime     *time.Time `json:"expire_time,omitempty"`
-	RemainingValue string     `json:"remaining_value,omitempty"`
+	RemainingValue *string    `json:"remaining_value,omitempty"`
 	StartTime      *time.Time `json:"start_time,omitempty"`
 	Type           CreditType `json:"type,omitempty"`
-	Value          string     `json:"value,omitempty"`
+	Value          *string    `json:"value,omitempty"`
 }
 type BillingGroupGetOut struct {
 	AccountId             string              `json:"account_id"`
 	AccountName           string              `json:"account_name"`
 	AddressLines          []string            `json:"address_lines"`
-	BillingAddress        string              `json:"billing_address,omitempty"`
+	BillingAddress        *string             `json:"billing_address,omitempty"`
 	BillingCurrency       BillingCurrencyType `json:"billing_currency"`
 	BillingEmails         []BillingEmailOut   `json:"billing_emails"`
 	BillingExtraText      string              `json:"billing_extra_text"`
@@ -339,7 +339,7 @@ type BillingGroupOut struct {
 	AccountId             string              `json:"account_id"`
 	AccountName           string              `json:"account_name"`
 	AddressLines          []string            `json:"address_lines"`
-	BillingAddress        string              `json:"billing_address,omitempty"`
+	BillingAddress        *string             `json:"billing_address,omitempty"`
 	BillingCurrency       BillingCurrencyType `json:"billing_currency"`
 	BillingEmails         []BillingEmailOut   `json:"billing_emails"`
 	BillingExtraText      string              `json:"billing_extra_text"`
@@ -373,25 +373,25 @@ func BillingGroupStateTypeChoices() []string {
 }
 
 type BillingGroupUpdateIn struct {
-	AccountId        string              `json:"account_id,omitempty"`
+	AccountId        *string             `json:"account_id,omitempty"`
 	AddressLines     *[]string           `json:"address_lines,omitempty"`
 	BillingCurrency  BillingCurrencyType `json:"billing_currency,omitempty"`
 	BillingEmails    *[]BillingEmailIn   `json:"billing_emails,omitempty"`
-	BillingExtraText string              `json:"billing_extra_text,omitempty"`
-	BillingGroupName string              `json:"billing_group_name,omitempty"`
-	CardId           string              `json:"card_id,omitempty"`
-	City             string              `json:"city,omitempty"`
-	Company          string              `json:"company,omitempty"`
-	CountryCode      string              `json:"country_code,omitempty"`
-	State            string              `json:"state,omitempty"`
-	VatId            string              `json:"vat_id,omitempty"`
-	ZipCode          string              `json:"zip_code,omitempty"`
+	BillingExtraText *string             `json:"billing_extra_text,omitempty"`
+	BillingGroupName *string             `json:"billing_group_name,omitempty"`
+	CardId           *string             `json:"card_id,omitempty"`
+	City             *string             `json:"city,omitempty"`
+	Company          *string             `json:"company,omitempty"`
+	CountryCode      *string             `json:"country_code,omitempty"`
+	State            *string             `json:"state,omitempty"`
+	VatId            *string             `json:"vat_id,omitempty"`
+	ZipCode          *string             `json:"zip_code,omitempty"`
 }
 type BillingGroupUpdateOut struct {
 	AccountId             string              `json:"account_id"`
 	AccountName           string              `json:"account_name"`
 	AddressLines          []string            `json:"address_lines"`
-	BillingAddress        string              `json:"billing_address,omitempty"`
+	BillingAddress        *string             `json:"billing_address,omitempty"`
 	BillingCurrency       BillingCurrencyType `json:"billing_currency"`
 	BillingEmails         []BillingEmailOut   `json:"billing_emails"`
 	BillingExtraText      string              `json:"billing_extra_text"`
@@ -422,12 +422,12 @@ type CardInfoOut struct {
 	UserEmail   string `json:"user_email"`
 }
 type CreditOut struct {
-	Code           string     `json:"code,omitempty"`
+	Code           *string    `json:"code,omitempty"`
 	ExpireTime     *time.Time `json:"expire_time,omitempty"`
-	RemainingValue string     `json:"remaining_value,omitempty"`
+	RemainingValue *string    `json:"remaining_value,omitempty"`
 	StartTime      *time.Time `json:"start_time,omitempty"`
 	Type           CreditType `json:"type,omitempty"`
-	Value          string     `json:"value,omitempty"`
+	Value          *string    `json:"value,omitempty"`
 }
 type CreditType string
 
@@ -473,14 +473,14 @@ func CurrencyTypeChoices() []string {
 }
 
 type EventOut struct {
-	Actor          string     `json:"actor,omitempty"`
-	BillingGroupId string     `json:"billing_group_id,omitempty"`
+	Actor          *string    `json:"actor,omitempty"`
+	BillingGroupId *string    `json:"billing_group_id,omitempty"`
 	CreateTime     *time.Time `json:"create_time,omitempty"`
-	EventDesc      string     `json:"event_desc,omitempty"`
-	EventType      string     `json:"event_type,omitempty"`
+	EventDesc      *string    `json:"event_desc,omitempty"`
+	EventType      *string    `json:"event_type,omitempty"`
 	LogEntryId     *int       `json:"log_entry_id,omitempty"`
-	ProjectId      string     `json:"project_id,omitempty"`
-	ProjectName    string     `json:"project_name,omitempty"`
+	ProjectId      *string    `json:"project_id,omitempty"`
+	ProjectName    *string    `json:"project_name,omitempty"`
 }
 type InvoiceOut struct {
 	BillingGroupId    string                `json:"billing_group_id"`
@@ -520,21 +520,21 @@ func InvoiceStateTypeChoices() []string {
 }
 
 type LineOut struct {
-	CloudName            string            `json:"cloud_name,omitempty"`
-	CommitmentName       string            `json:"commitment_name,omitempty"`
+	CloudName            *string           `json:"cloud_name,omitempty"`
+	CommitmentName       *string           `json:"commitment_name,omitempty"`
 	Description          string            `json:"description"`
-	LinePreDiscountLocal string            `json:"line_pre_discount_local,omitempty"`
-	LineTotalLocal       string            `json:"line_total_local,omitempty"`
+	LinePreDiscountLocal *string           `json:"line_pre_discount_local,omitempty"`
+	LineTotalLocal       *string           `json:"line_total_local,omitempty"`
 	LineTotalUsd         string            `json:"line_total_usd"`
 	LineType             LineType          `json:"line_type"`
-	LocalCurrency        string            `json:"local_currency,omitempty"`
-	ProjectName          string            `json:"project_name,omitempty"`
-	ServiceName          string            `json:"service_name,omitempty"`
-	ServicePlan          string            `json:"service_plan,omitempty"`
+	LocalCurrency        *string           `json:"local_currency,omitempty"`
+	ProjectName          *string           `json:"project_name,omitempty"`
+	ServiceName          *string           `json:"service_name,omitempty"`
+	ServicePlan          *string           `json:"service_plan,omitempty"`
 	ServiceType          ServiceType       `json:"service_type,omitempty"`
 	Tags                 map[string]string `json:"tags,omitempty"`
-	TimestampBegin       string            `json:"timestamp_begin,omitempty"`
-	TimestampEnd         string            `json:"timestamp_end,omitempty"`
+	TimestampBegin       *string           `json:"timestamp_begin,omitempty"`
+	TimestampEnd         *string           `json:"timestamp_end,omitempty"`
 }
 type LineType string
 

--- a/handler/clickhouse/clickhouse.go
+++ b/handler/clickhouse/clickhouse.go
@@ -153,29 +153,29 @@ func DatabaseStateTypeChoices() []string {
 }
 
 type HourlyOut struct {
-	EstimatedCost   string `json:"estimated_cost,omitempty"`
-	HourStart       string `json:"hour_start"`
-	PeakStoredBytes int    `json:"peak_stored_bytes"`
+	EstimatedCost   *string `json:"estimated_cost,omitempty"`
+	HourStart       string  `json:"hour_start"`
+	PeakStoredBytes int     `json:"peak_stored_bytes"`
 }
 type MetaOut struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
 }
 type QueryOut struct {
-	ClientName string   `json:"client_name,omitempty"`
-	Database   string   `json:"database,omitempty"`
+	ClientName *string  `json:"client_name,omitempty"`
+	Database   *string  `json:"database,omitempty"`
 	Elapsed    *float64 `json:"elapsed,omitempty"`
-	Query      string   `json:"query,omitempty"`
-	User       string   `json:"user,omitempty"`
+	Query      *string  `json:"query,omitempty"`
+	User       *string  `json:"user,omitempty"`
 }
 type QueryOutAlt struct {
 	Calls      *int     `json:"calls,omitempty"`
-	Database   string   `json:"database,omitempty"`
+	Database   *string  `json:"database,omitempty"`
 	MaxTime    *int     `json:"max_time,omitempty"`
 	MeanTime   *int     `json:"mean_time,omitempty"`
 	MinTime    *int     `json:"min_time,omitempty"`
 	P95Time    *int     `json:"p95_time,omitempty"`
-	Query      string   `json:"query,omitempty"`
+	Query      *string  `json:"query,omitempty"`
 	Rows       *float64 `json:"rows,omitempty"`
 	StddevTime *int     `json:"stddev_time,omitempty"`
 	TotalTime  *int     `json:"total_time,omitempty"`
@@ -195,7 +195,7 @@ type ServiceClickHouseQueryOut struct {
 type ServiceClickHouseTieredStorageSummaryOut struct {
 	CurrentCost         string                 `json:"current_cost"`
 	ForecastedCost      string                 `json:"forecasted_cost"`
-	ForecastedRate      string                 `json:"forecasted_rate,omitempty"`
+	ForecastedRate      *string                `json:"forecasted_rate,omitempty"`
 	StorageUsageHistory StorageUsageHistoryOut `json:"storage_usage_history"`
 	TotalStorageUsage   int                    `json:"total_storage_usage"`
 }

--- a/handler/cloud/cloud.go
+++ b/handler/cloud/cloud.go
@@ -61,13 +61,13 @@ func (h *CloudHandler) ListProjectClouds(ctx context.Context, project string) ([
 }
 
 type CloudOut struct {
-	CloudDescription    string   `json:"cloud_description,omitempty"`
+	CloudDescription    *string  `json:"cloud_description,omitempty"`
 	CloudName           string   `json:"cloud_name"`
 	GeoLatitude         *float64 `json:"geo_latitude,omitempty"`
 	GeoLongitude        *float64 `json:"geo_longitude,omitempty"`
 	GeoRegion           string   `json:"geo_region"`
-	Provider            string   `json:"provider,omitempty"`
-	ProviderDescription string   `json:"provider_description,omitempty"`
+	Provider            *string  `json:"provider,omitempty"`
+	ProviderDescription *string  `json:"provider_description,omitempty"`
 }
 type listCloudsOut struct {
 	Clouds []CloudOut `json:"clouds"`

--- a/handler/flink/flink.go
+++ b/handler/flink/flink.go
@@ -43,13 +43,13 @@ func (h *FlinkHandler) ServiceFlinkOverview(ctx context.Context, project string,
 }
 
 type ServiceFlinkOverviewOut struct {
-	FlinkCommit    string `json:"flink-commit,omitempty"`
-	FlinkVersion   string `json:"flink-version,omitempty"`
-	JobsCancelled  *int   `json:"jobs-cancelled,omitempty"`
-	JobsFailed     *int   `json:"jobs-failed,omitempty"`
-	JobsFinished   *int   `json:"jobs-finished,omitempty"`
-	JobsRunning    *int   `json:"jobs-running,omitempty"`
-	SlotsAvailable *int   `json:"slots-available,omitempty"`
-	SlotsTotal     *int   `json:"slots-total,omitempty"`
-	Taskmanagers   *int   `json:"taskmanagers,omitempty"`
+	FlinkCommit    *string `json:"flink-commit,omitempty"`
+	FlinkVersion   *string `json:"flink-version,omitempty"`
+	JobsCancelled  *int    `json:"jobs-cancelled,omitempty"`
+	JobsFailed     *int    `json:"jobs-failed,omitempty"`
+	JobsFinished   *int    `json:"jobs-finished,omitempty"`
+	JobsRunning    *int    `json:"jobs-running,omitempty"`
+	SlotsAvailable *int    `json:"slots-available,omitempty"`
+	SlotsTotal     *int    `json:"slots-total,omitempty"`
+	Taskmanagers   *int    `json:"taskmanagers,omitempty"`
 }

--- a/handler/flinkapplication/flinkapplication.go
+++ b/handler/flinkapplication/flinkapplication.go
@@ -117,11 +117,11 @@ func (h *FlinkApplicationHandler) ServiceFlinkUpdateApplication(ctx context.Cont
 
 type ApplicationOut struct {
 	CreatedAt *time.Time `json:"created_at,omitempty"`
-	CreatedBy string     `json:"created_by,omitempty"`
+	CreatedBy *string    `json:"created_by,omitempty"`
 	Id        string     `json:"id"`
 	Name      string     `json:"name"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
-	UpdatedBy string     `json:"updated_by,omitempty"`
+	UpdatedBy *string    `json:"updated_by,omitempty"`
 }
 type ApplicationVersionIn struct {
 	Sinks     []SinkIn   `json:"sinks"`
@@ -138,23 +138,23 @@ type ApplicationVersionOut struct {
 	Version   int         `json:"version"`
 }
 type ColumnOut struct {
-	DataType  string `json:"data_type"`
-	Extras    string `json:"extras,omitempty"`
-	Key       string `json:"key,omitempty"`
-	Name      string `json:"name"`
-	Nullable  bool   `json:"nullable"`
-	Watermark string `json:"watermark,omitempty"`
+	DataType  string  `json:"data_type"`
+	Extras    *string `json:"extras,omitempty"`
+	Key       *string `json:"key,omitempty"`
+	Name      string  `json:"name"`
+	Nullable  bool    `json:"nullable"`
+	Watermark *string `json:"watermark,omitempty"`
 }
 type CurrentDeploymentOut struct {
 	CreatedAt         time.Time                   `json:"created_at"`
 	CreatedBy         string                      `json:"created_by"`
-	ErrorMsg          string                      `json:"error_msg,omitempty"`
+	ErrorMsg          *string                     `json:"error_msg,omitempty"`
 	Id                string                      `json:"id"`
-	JobId             string                      `json:"job_id,omitempty"`
-	LastSavepoint     string                      `json:"last_savepoint,omitempty"`
+	JobId             *string                     `json:"job_id,omitempty"`
+	LastSavepoint     *string                     `json:"last_savepoint,omitempty"`
 	Parallelism       int                         `json:"parallelism"`
 	RestartEnabled    bool                        `json:"restart_enabled"`
-	StartingSavepoint string                      `json:"starting_savepoint,omitempty"`
+	StartingSavepoint *string                     `json:"starting_savepoint,omitempty"`
 	Status            CurrentDeploymentStatusType `json:"status"`
 	VersionId         string                      `json:"version_id"`
 }
@@ -232,25 +232,25 @@ type ServiceFlinkUpdateApplicationOut struct {
 	UpdatedBy           string                  `json:"updated_by"`
 }
 type SinkIn struct {
-	CreateTable   string `json:"create_table"`
-	IntegrationId string `json:"integration_id,omitempty"`
+	CreateTable   string  `json:"create_table"`
+	IntegrationId *string `json:"integration_id,omitempty"`
 }
 type SinkOut struct {
 	Columns       []ColumnOut    `json:"columns"`
 	CreateTable   string         `json:"create_table"`
-	IntegrationId string         `json:"integration_id,omitempty"`
+	IntegrationId *string        `json:"integration_id,omitempty"`
 	Options       map[string]any `json:"options"`
 	TableId       string         `json:"table_id"`
 	TableName     string         `json:"table_name"`
 }
 type SourceIn struct {
-	CreateTable   string `json:"create_table"`
-	IntegrationId string `json:"integration_id,omitempty"`
+	CreateTable   string  `json:"create_table"`
+	IntegrationId *string `json:"integration_id,omitempty"`
 }
 type SourceOut struct {
 	Columns       []ColumnOut    `json:"columns"`
 	CreateTable   string         `json:"create_table"`
-	IntegrationId string         `json:"integration_id,omitempty"`
+	IntegrationId *string        `json:"integration_id,omitempty"`
 	Options       map[string]any `json:"options"`
 	TableId       string         `json:"table_id"`
 	TableName     string         `json:"table_name"`

--- a/handler/flinkapplicationdeployment/flinkapplicationdeployment.go
+++ b/handler/flinkapplicationdeployment/flinkapplicationdeployment.go
@@ -136,13 +136,13 @@ func (h *FlinkApplicationDeploymentHandler) ServiceFlinkStopApplicationDeploymen
 type DeploymentOut struct {
 	CreatedAt         time.Time            `json:"created_at"`
 	CreatedBy         string               `json:"created_by"`
-	ErrorMsg          string               `json:"error_msg,omitempty"`
+	ErrorMsg          *string              `json:"error_msg,omitempty"`
 	Id                string               `json:"id"`
-	JobId             string               `json:"job_id,omitempty"`
-	LastSavepoint     string               `json:"last_savepoint,omitempty"`
+	JobId             *string              `json:"job_id,omitempty"`
+	LastSavepoint     *string              `json:"last_savepoint,omitempty"`
 	Parallelism       int                  `json:"parallelism"`
 	RestartEnabled    bool                 `json:"restart_enabled"`
-	StartingSavepoint string               `json:"starting_savepoint,omitempty"`
+	StartingSavepoint *string              `json:"starting_savepoint,omitempty"`
 	Status            DeploymentStatusType `json:"status"`
 	VersionId         string               `json:"version_id"`
 }
@@ -201,71 +201,71 @@ func ServiceFlinkApplicationDeploymentStatusTypeChoices() []string {
 type ServiceFlinkCancelApplicationDeploymentOut struct {
 	CreatedAt         time.Time                                   `json:"created_at"`
 	CreatedBy         string                                      `json:"created_by"`
-	ErrorMsg          string                                      `json:"error_msg,omitempty"`
+	ErrorMsg          *string                                     `json:"error_msg,omitempty"`
 	Id                string                                      `json:"id"`
-	JobId             string                                      `json:"job_id,omitempty"`
-	LastSavepoint     string                                      `json:"last_savepoint,omitempty"`
+	JobId             *string                                     `json:"job_id,omitempty"`
+	LastSavepoint     *string                                     `json:"last_savepoint,omitempty"`
 	Parallelism       int                                         `json:"parallelism"`
 	RestartEnabled    bool                                        `json:"restart_enabled"`
-	StartingSavepoint string                                      `json:"starting_savepoint,omitempty"`
+	StartingSavepoint *string                                     `json:"starting_savepoint,omitempty"`
 	Status            ServiceFlinkApplicationDeploymentStatusType `json:"status"`
 	VersionId         string                                      `json:"version_id"`
 }
 type ServiceFlinkCreateApplicationDeploymentIn struct {
-	Parallelism       *int   `json:"parallelism,omitempty"`
-	RestartEnabled    *bool  `json:"restart_enabled,omitempty"`
-	StartingSavepoint string `json:"starting_savepoint,omitempty"`
-	VersionId         string `json:"version_id"`
+	Parallelism       *int    `json:"parallelism,omitempty"`
+	RestartEnabled    *bool   `json:"restart_enabled,omitempty"`
+	StartingSavepoint *string `json:"starting_savepoint,omitempty"`
+	VersionId         string  `json:"version_id"`
 }
 type ServiceFlinkCreateApplicationDeploymentOut struct {
 	CreatedAt         time.Time                                   `json:"created_at"`
 	CreatedBy         string                                      `json:"created_by"`
-	ErrorMsg          string                                      `json:"error_msg,omitempty"`
+	ErrorMsg          *string                                     `json:"error_msg,omitempty"`
 	Id                string                                      `json:"id"`
-	JobId             string                                      `json:"job_id,omitempty"`
-	LastSavepoint     string                                      `json:"last_savepoint,omitempty"`
+	JobId             *string                                     `json:"job_id,omitempty"`
+	LastSavepoint     *string                                     `json:"last_savepoint,omitempty"`
 	Parallelism       int                                         `json:"parallelism"`
 	RestartEnabled    bool                                        `json:"restart_enabled"`
-	StartingSavepoint string                                      `json:"starting_savepoint,omitempty"`
+	StartingSavepoint *string                                     `json:"starting_savepoint,omitempty"`
 	Status            ServiceFlinkApplicationDeploymentStatusType `json:"status"`
 	VersionId         string                                      `json:"version_id"`
 }
 type ServiceFlinkDeleteApplicationDeploymentOut struct {
 	CreatedAt         time.Time                                   `json:"created_at"`
 	CreatedBy         string                                      `json:"created_by"`
-	ErrorMsg          string                                      `json:"error_msg,omitempty"`
+	ErrorMsg          *string                                     `json:"error_msg,omitempty"`
 	Id                string                                      `json:"id"`
-	JobId             string                                      `json:"job_id,omitempty"`
-	LastSavepoint     string                                      `json:"last_savepoint,omitempty"`
+	JobId             *string                                     `json:"job_id,omitempty"`
+	LastSavepoint     *string                                     `json:"last_savepoint,omitempty"`
 	Parallelism       int                                         `json:"parallelism"`
 	RestartEnabled    bool                                        `json:"restart_enabled"`
-	StartingSavepoint string                                      `json:"starting_savepoint,omitempty"`
+	StartingSavepoint *string                                     `json:"starting_savepoint,omitempty"`
 	Status            ServiceFlinkApplicationDeploymentStatusType `json:"status"`
 	VersionId         string                                      `json:"version_id"`
 }
 type ServiceFlinkGetApplicationDeploymentOut struct {
 	CreatedAt         time.Time                                   `json:"created_at"`
 	CreatedBy         string                                      `json:"created_by"`
-	ErrorMsg          string                                      `json:"error_msg,omitempty"`
+	ErrorMsg          *string                                     `json:"error_msg,omitempty"`
 	Id                string                                      `json:"id"`
-	JobId             string                                      `json:"job_id,omitempty"`
-	LastSavepoint     string                                      `json:"last_savepoint,omitempty"`
+	JobId             *string                                     `json:"job_id,omitempty"`
+	LastSavepoint     *string                                     `json:"last_savepoint,omitempty"`
 	Parallelism       int                                         `json:"parallelism"`
 	RestartEnabled    bool                                        `json:"restart_enabled"`
-	StartingSavepoint string                                      `json:"starting_savepoint,omitempty"`
+	StartingSavepoint *string                                     `json:"starting_savepoint,omitempty"`
 	Status            ServiceFlinkApplicationDeploymentStatusType `json:"status"`
 	VersionId         string                                      `json:"version_id"`
 }
 type ServiceFlinkStopApplicationDeploymentOut struct {
 	CreatedAt         time.Time                                   `json:"created_at"`
 	CreatedBy         string                                      `json:"created_by"`
-	ErrorMsg          string                                      `json:"error_msg,omitempty"`
+	ErrorMsg          *string                                     `json:"error_msg,omitempty"`
 	Id                string                                      `json:"id"`
-	JobId             string                                      `json:"job_id,omitempty"`
-	LastSavepoint     string                                      `json:"last_savepoint,omitempty"`
+	JobId             *string                                     `json:"job_id,omitempty"`
+	LastSavepoint     *string                                     `json:"last_savepoint,omitempty"`
 	Parallelism       int                                         `json:"parallelism"`
 	RestartEnabled    bool                                        `json:"restart_enabled"`
-	StartingSavepoint string                                      `json:"starting_savepoint,omitempty"`
+	StartingSavepoint *string                                     `json:"starting_savepoint,omitempty"`
 	Status            ServiceFlinkApplicationDeploymentStatusType `json:"status"`
 	VersionId         string                                      `json:"version_id"`
 }

--- a/handler/flinkapplicationversion/flinkapplicationversion.go
+++ b/handler/flinkapplicationversion/flinkapplicationversion.go
@@ -98,12 +98,12 @@ func (h *FlinkApplicationVersionHandler) ServiceFlinkValidateApplicationVersion(
 }
 
 type ColumnOut struct {
-	DataType  string `json:"data_type"`
-	Extras    string `json:"extras,omitempty"`
-	Key       string `json:"key,omitempty"`
-	Name      string `json:"name"`
-	Nullable  bool   `json:"nullable"`
-	Watermark string `json:"watermark,omitempty"`
+	DataType  string  `json:"data_type"`
+	Extras    *string `json:"extras,omitempty"`
+	Key       *string `json:"key,omitempty"`
+	Name      string  `json:"name"`
+	Nullable  bool    `json:"nullable"`
+	Watermark *string `json:"watermark,omitempty"`
 }
 type PositionOut struct {
 	CharacterNumber    int `json:"character_number"`
@@ -146,22 +146,22 @@ type ServiceFlinkGetApplicationVersionOut struct {
 type ServiceFlinkValidateApplicationVersionIn struct {
 	Sinks     []SinkIn   `json:"sinks"`
 	Sources   []SourceIn `json:"sources"`
-	Statement string     `json:"statement,omitempty"`
+	Statement *string    `json:"statement,omitempty"`
 }
 type ServiceFlinkValidateApplicationVersionOut struct {
 	Sinks          []SinkOutAlt       `json:"sinks"`
 	Sources        []SourceOutAlt     `json:"sources"`
-	Statement      string             `json:"statement,omitempty"`
+	Statement      *string            `json:"statement,omitempty"`
 	StatementError *StatementErrorOut `json:"statement_error,omitempty"`
 }
 type SinkIn struct {
-	CreateTable   string `json:"create_table"`
-	IntegrationId string `json:"integration_id,omitempty"`
+	CreateTable   string  `json:"create_table"`
+	IntegrationId *string `json:"integration_id,omitempty"`
 }
 type SinkOut struct {
 	Columns       []ColumnOut    `json:"columns"`
 	CreateTable   string         `json:"create_table"`
-	IntegrationId string         `json:"integration_id,omitempty"`
+	IntegrationId *string        `json:"integration_id,omitempty"`
 	Options       map[string]any `json:"options"`
 	TableId       string         `json:"table_id"`
 	TableName     string         `json:"table_name"`
@@ -169,20 +169,20 @@ type SinkOut struct {
 type SinkOutAlt struct {
 	Columns       []ColumnOut    `json:"columns,omitempty"`
 	CreateTable   string         `json:"create_table"`
-	IntegrationId string         `json:"integration_id,omitempty"`
-	Message       string         `json:"message,omitempty"`
+	IntegrationId *string        `json:"integration_id,omitempty"`
+	Message       *string        `json:"message,omitempty"`
 	Options       map[string]any `json:"options,omitempty"`
 	Position      *PositionOut   `json:"position,omitempty"`
-	TableName     string         `json:"table_name,omitempty"`
+	TableName     *string        `json:"table_name,omitempty"`
 }
 type SourceIn struct {
-	CreateTable   string `json:"create_table"`
-	IntegrationId string `json:"integration_id,omitempty"`
+	CreateTable   string  `json:"create_table"`
+	IntegrationId *string `json:"integration_id,omitempty"`
 }
 type SourceOut struct {
 	Columns       []ColumnOut    `json:"columns"`
 	CreateTable   string         `json:"create_table"`
-	IntegrationId string         `json:"integration_id,omitempty"`
+	IntegrationId *string        `json:"integration_id,omitempty"`
 	Options       map[string]any `json:"options"`
 	TableId       string         `json:"table_id"`
 	TableName     string         `json:"table_name"`
@@ -190,11 +190,11 @@ type SourceOut struct {
 type SourceOutAlt struct {
 	Columns       []ColumnOut    `json:"columns,omitempty"`
 	CreateTable   string         `json:"create_table"`
-	IntegrationId string         `json:"integration_id,omitempty"`
-	Message       string         `json:"message,omitempty"`
+	IntegrationId *string        `json:"integration_id,omitempty"`
+	Message       *string        `json:"message,omitempty"`
 	Options       map[string]any `json:"options,omitempty"`
 	Position      *PositionOut   `json:"position,omitempty"`
-	TableName     string         `json:"table_name,omitempty"`
+	TableName     *string        `json:"table_name,omitempty"`
 }
 type StatementErrorOut struct {
 	Message  string       `json:"message"`

--- a/handler/flinkjob/flinkjob.go
+++ b/handler/flinkjob/flinkjob.go
@@ -61,7 +61,7 @@ func (h *FlinkJobHandler) ServiceFlinkJobsList(ctx context.Context, project stri
 }
 
 type JobOut struct {
-	Id     string        `json:"id,omitempty"`
+	Id     *string       `json:"id,omitempty"`
 	Status JobStatusType `json:"status,omitempty"`
 }
 type JobStatusType string
@@ -88,9 +88,9 @@ type ServiceFlinkJobDetailsOut struct {
 	Duration       *int                            `json:"duration,omitempty"`
 	EndTime        *int                            `json:"end-time,omitempty"`
 	IsStoppable    *bool                           `json:"isStoppable,omitempty"`
-	Jid            string                          `json:"jid,omitempty"`
+	Jid            *string                         `json:"jid,omitempty"`
 	MaxParallelism *int                            `json:"maxParallelism,omitempty"`
-	Name           string                          `json:"name,omitempty"`
+	Name           *string                         `json:"name,omitempty"`
 	Now            *int                            `json:"now,omitempty"`
 	Plan           map[string]any                  `json:"plan,omitempty"`
 	StartTime      *int                            `json:"start-time,omitempty"`

--- a/handler/kafka/kafka.go
+++ b/handler/kafka/kafka.go
@@ -189,15 +189,15 @@ func (h *KafkaHandler) ServiceKafkaTieredStorageSummary(ctx context.Context, pro
 }
 
 type AclOut struct {
-	Id         string         `json:"id,omitempty"`
+	Id         *string        `json:"id,omitempty"`
 	Permission PermissionType `json:"permission"`
 	Topic      string         `json:"topic"`
 	Username   string         `json:"username"`
 }
 type HourlyOut struct {
-	EstimatedCost   string `json:"estimated_cost,omitempty"`
-	HourStart       string `json:"hour_start"`
-	PeakStoredBytes int    `json:"peak_stored_bytes"`
+	EstimatedCost   *string `json:"estimated_cost,omitempty"`
+	HourStart       string  `json:"hour_start"`
+	PeakStoredBytes int     `json:"peak_stored_bytes"`
 }
 type PermissionType string
 
@@ -213,7 +213,7 @@ func PermissionTypeChoices() []string {
 }
 
 type QuotaOut struct {
-	ClientId          string  `json:"client-id,omitempty"`
+	ClientId          *string `json:"client-id,omitempty"`
 	ConsumerByteRate  float64 `json:"consumer_byte_rate"`
 	ProducerByteRate  float64 `json:"producer_byte_rate"`
 	RequestPercentage float64 `json:"request_percentage"`
@@ -225,14 +225,14 @@ type ServiceKafkaAclAddIn struct {
 	Username   string         `json:"username"`
 }
 type ServiceKafkaQuotaCreateIn struct {
-	ClientId          string   `json:"client-id,omitempty"`
+	ClientId          *string  `json:"client-id,omitempty"`
 	ConsumerByteRate  *float64 `json:"consumer_byte_rate,omitempty"`
 	ProducerByteRate  *float64 `json:"producer_byte_rate,omitempty"`
 	RequestPercentage *float64 `json:"request_percentage,omitempty"`
-	User              string   `json:"user,omitempty"`
+	User              *string  `json:"user,omitempty"`
 }
 type ServiceKafkaQuotaDescribeOut struct {
-	ClientId          string  `json:"client-id,omitempty"`
+	ClientId          *string `json:"client-id,omitempty"`
 	ConsumerByteRate  float64 `json:"consumer_byte_rate"`
 	ProducerByteRate  float64 `json:"producer_byte_rate"`
 	RequestPercentage float64 `json:"request_percentage"`
@@ -241,7 +241,7 @@ type ServiceKafkaQuotaDescribeOut struct {
 type ServiceKafkaTieredStorageSummaryOut struct {
 	CurrentCost         string                 `json:"current_cost"`
 	ForecastedCost      string                 `json:"forecasted_cost"`
-	ForecastedRate      string                 `json:"forecasted_rate,omitempty"`
+	ForecastedRate      *string                `json:"forecasted_rate,omitempty"`
 	StorageUsageHistory StorageUsageHistoryOut `json:"storage_usage_history"`
 	TotalStorageUsage   int                    `json:"total_storage_usage"`
 }

--- a/handler/kafkaconnect/kafkaconnect.go
+++ b/handler/kafkaconnect/kafkaconnect.go
@@ -183,8 +183,8 @@ func (h *KafkaConnectHandler) ServiceKafkaConnectResumeConnector(ctx context.Con
 }
 
 type ConfigOut struct {
-	ConnectorClass string `json:"connector.class,omitempty"`
-	Name           string `json:"name"`
+	ConnectorClass *string `json:"connector.class,omitempty"`
+	Name           string  `json:"name"`
 }
 type ConfigurationSchemaOut struct {
 	DefaultValue  string                  `json:"default_value"`
@@ -239,7 +239,7 @@ type PluginOut struct {
 	Class       string     `json:"class"`
 	DocUrl      string     `json:"docURL"`
 	Preview     *bool      `json:"preview,omitempty"`
-	PreviewInfo string     `json:"preview_info,omitempty"`
+	PreviewInfo *string    `json:"preview_info,omitempty"`
 	Title       string     `json:"title"`
 	Type        PluginType `json:"type"`
 	Version     string     `json:"version"`
@@ -270,8 +270,8 @@ func ServiceKafkaConnectConnectorStateTypeChoices() []string {
 }
 
 type ServiceKafkaConnectCreateConnectorIn struct {
-	ConnectorClass string `json:"connector.class,omitempty"`
-	Name           string `json:"name"`
+	ConnectorClass *string `json:"connector.class,omitempty"`
+	Name           string  `json:"name"`
 }
 type ServiceKafkaConnectCreateConnectorOut struct {
 	Config ConfigOut `json:"config"`
@@ -280,8 +280,8 @@ type ServiceKafkaConnectCreateConnectorOut struct {
 	Tasks  []TaskOut `json:"tasks"`
 }
 type ServiceKafkaConnectEditConnectorIn struct {
-	ConnectorClass string `json:"connector.class,omitempty"`
-	Name           string `json:"name"`
+	ConnectorClass *string `json:"connector.class,omitempty"`
+	Name           string  `json:"name"`
 }
 type ServiceKafkaConnectEditConnectorOut struct {
 	Config ConfigOut `json:"config"`

--- a/handler/kafkamirrormaker/kafkamirrormaker.go
+++ b/handler/kafkamirrormaker/kafkamirrormaker.go
@@ -110,7 +110,7 @@ func OffsetSyncsTopicLocationTypeChoices() []string {
 }
 
 type ReplicationFlowOut struct {
-	ConfigPropertiesExclude         string                       `json:"config_properties_exclude,omitempty"`
+	ConfigPropertiesExclude         *string                      `json:"config_properties_exclude,omitempty"`
 	EmitBackwardHeartbeatsEnabled   *bool                        `json:"emit_backward_heartbeats_enabled,omitempty"`
 	EmitHeartbeatsEnabled           *bool                        `json:"emit_heartbeats_enabled,omitempty"`
 	Enabled                         bool                         `json:"enabled"`
@@ -124,7 +124,7 @@ type ReplicationFlowOut struct {
 	SyncGroupOffsetsIntervalSeconds *int                         `json:"sync_group_offsets_interval_seconds,omitempty"`
 	TargetCluster                   string                       `json:"target_cluster"`
 	Topics                          []string                     `json:"topics,omitempty"`
-	TopicsBlacklist                 string                       `json:"topics.blacklist,omitempty"`
+	TopicsBlacklist                 *string                      `json:"topics.blacklist,omitempty"`
 }
 type ReplicationPolicyClassType string
 
@@ -138,7 +138,7 @@ func ReplicationPolicyClassTypeChoices() []string {
 }
 
 type ServiceKafkaMirrorMakerCreateReplicationFlowIn struct {
-	ConfigPropertiesExclude         string                       `json:"config_properties_exclude,omitempty"`
+	ConfigPropertiesExclude         *string                      `json:"config_properties_exclude,omitempty"`
 	EmitBackwardHeartbeatsEnabled   *bool                        `json:"emit_backward_heartbeats_enabled,omitempty"`
 	EmitHeartbeatsEnabled           *bool                        `json:"emit_heartbeats_enabled,omitempty"`
 	Enabled                         bool                         `json:"enabled"`
@@ -151,10 +151,10 @@ type ServiceKafkaMirrorMakerCreateReplicationFlowIn struct {
 	SyncGroupOffsetsIntervalSeconds *int                         `json:"sync_group_offsets_interval_seconds,omitempty"`
 	TargetCluster                   string                       `json:"target_cluster"`
 	Topics                          *[]string                    `json:"topics,omitempty"`
-	TopicsBlacklist                 string                       `json:"topics.blacklist,omitempty"`
+	TopicsBlacklist                 *string                      `json:"topics.blacklist,omitempty"`
 }
 type ServiceKafkaMirrorMakerGetReplicationFlowOut struct {
-	ConfigPropertiesExclude         string                       `json:"config_properties_exclude,omitempty"`
+	ConfigPropertiesExclude         *string                      `json:"config_properties_exclude,omitempty"`
 	EmitBackwardHeartbeatsEnabled   *bool                        `json:"emit_backward_heartbeats_enabled,omitempty"`
 	EmitHeartbeatsEnabled           *bool                        `json:"emit_heartbeats_enabled,omitempty"`
 	Enabled                         bool                         `json:"enabled"`
@@ -168,10 +168,10 @@ type ServiceKafkaMirrorMakerGetReplicationFlowOut struct {
 	SyncGroupOffsetsIntervalSeconds *int                         `json:"sync_group_offsets_interval_seconds,omitempty"`
 	TargetCluster                   string                       `json:"target_cluster"`
 	Topics                          []string                     `json:"topics,omitempty"`
-	TopicsBlacklist                 string                       `json:"topics.blacklist,omitempty"`
+	TopicsBlacklist                 *string                      `json:"topics.blacklist,omitempty"`
 }
 type ServiceKafkaMirrorMakerPatchReplicationFlowIn struct {
-	ConfigPropertiesExclude         string                       `json:"config_properties_exclude,omitempty"`
+	ConfigPropertiesExclude         *string                      `json:"config_properties_exclude,omitempty"`
 	EmitBackwardHeartbeatsEnabled   *bool                        `json:"emit_backward_heartbeats_enabled,omitempty"`
 	EmitHeartbeatsEnabled           *bool                        `json:"emit_heartbeats_enabled,omitempty"`
 	Enabled                         *bool                        `json:"enabled,omitempty"`
@@ -182,10 +182,10 @@ type ServiceKafkaMirrorMakerPatchReplicationFlowIn struct {
 	SyncGroupOffsetsEnabled         *bool                        `json:"sync_group_offsets_enabled,omitempty"`
 	SyncGroupOffsetsIntervalSeconds *int                         `json:"sync_group_offsets_interval_seconds,omitempty"`
 	Topics                          *[]string                    `json:"topics,omitempty"`
-	TopicsBlacklist                 string                       `json:"topics.blacklist,omitempty"`
+	TopicsBlacklist                 *string                      `json:"topics.blacklist,omitempty"`
 }
 type ServiceKafkaMirrorMakerPatchReplicationFlowOut struct {
-	ConfigPropertiesExclude         string                       `json:"config_properties_exclude,omitempty"`
+	ConfigPropertiesExclude         *string                      `json:"config_properties_exclude,omitempty"`
 	EmitBackwardHeartbeatsEnabled   *bool                        `json:"emit_backward_heartbeats_enabled,omitempty"`
 	EmitHeartbeatsEnabled           *bool                        `json:"emit_heartbeats_enabled,omitempty"`
 	Enabled                         bool                         `json:"enabled"`
@@ -199,7 +199,7 @@ type ServiceKafkaMirrorMakerPatchReplicationFlowOut struct {
 	SyncGroupOffsetsIntervalSeconds *int                         `json:"sync_group_offsets_interval_seconds,omitempty"`
 	TargetCluster                   string                       `json:"target_cluster"`
 	Topics                          []string                     `json:"topics,omitempty"`
-	TopicsBlacklist                 string                       `json:"topics.blacklist,omitempty"`
+	TopicsBlacklist                 *string                      `json:"topics.blacklist,omitempty"`
 }
 type serviceKafkaMirrorMakerGetReplicationFlowOut struct {
 	ReplicationFlow ServiceKafkaMirrorMakerGetReplicationFlowOut `json:"replication_flow"`

--- a/handler/kafkaschemaregistry/kafkaschemaregistry.go
+++ b/handler/kafkaschemaregistry/kafkaschemaregistry.go
@@ -263,7 +263,7 @@ func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistrySubjects(ctx context.C
 }
 
 type AclOut struct {
-	Id         string         `json:"id,omitempty"`
+	Id         *string        `json:"id,omitempty"`
 	Permission PermissionType `json:"permission"`
 	Resource   string         `json:"resource"`
 	Username   string         `json:"username"`

--- a/handler/kafkatopic/kafkatopic.go
+++ b/handler/kafkatopic/kafkatopic.go
@@ -129,7 +129,7 @@ func (h *KafkaTopicHandler) ServiceKafkaTopicUpdate(ctx context.Context, project
 type CleanupPolicyOut struct {
 	Source   SourceType   `json:"source,omitempty"`
 	Synonyms []SynonymOut `json:"synonyms,omitempty"`
-	Value    string       `json:"value,omitempty"`
+	Value    *string      `json:"value,omitempty"`
 }
 type CleanupPolicyType string
 
@@ -398,7 +398,7 @@ type MessageOut struct {
 	Key       map[string]any `json:"key,omitempty"`
 	Offset    *int           `json:"offset,omitempty"`
 	Partition *int           `json:"partition,omitempty"`
-	Topic     string         `json:"topic,omitempty"`
+	Topic     *string        `json:"topic,omitempty"`
 	Value     map[string]any `json:"value,omitempty"`
 }
 type MessageTimestampDifferenceMaxMsOut struct {
@@ -449,10 +449,10 @@ type MinInsyncReplicasOut struct {
 	Value    *int         `json:"value,omitempty"`
 }
 type OffsetOut struct {
-	Error     string `json:"error,omitempty"`
-	ErrorCode *int   `json:"error_code,omitempty"`
-	Offset    *int   `json:"offset,omitempty"`
-	Partition *int   `json:"partition,omitempty"`
+	Error     *string `json:"error,omitempty"`
+	ErrorCode *int    `json:"error_code,omitempty"`
+	Offset    *int    `json:"offset,omitempty"`
+	Partition *int    `json:"partition,omitempty"`
 }
 type PartitionOut struct {
 	ConsumerGroups []ConsumerGroupOut `json:"consumer_groups"`
@@ -539,10 +539,10 @@ type ServiceKafkaTopicMessageListIn struct {
 }
 type ServiceKafkaTopicMessageProduceIn struct {
 	Format        FormatType `json:"format"`
-	KeySchema     string     `json:"key_schema,omitempty"`
+	KeySchema     *string    `json:"key_schema,omitempty"`
 	KeySchemaId   *int       `json:"key_schema_id,omitempty"`
 	Records       []RecordIn `json:"records"`
-	ValueSchema   string     `json:"value_schema,omitempty"`
+	ValueSchema   *string    `json:"value_schema,omitempty"`
 	ValueSchemaId *int       `json:"value_schema_id,omitempty"`
 }
 type ServiceKafkaTopicMessageProduceOut struct {
@@ -576,7 +576,7 @@ func SourceTypeChoices() []string {
 }
 
 type SynonymOut struct {
-	Name   string     `json:"name,omitempty"`
+	Name   *string    `json:"name,omitempty"`
 	Source SourceType `json:"source,omitempty"`
 	Value  *bool      `json:"value,omitempty"`
 }

--- a/handler/mysql/mysql.go
+++ b/handler/mysql/mysql.go
@@ -43,26 +43,26 @@ func (h *MySQLHandler) MySQLServiceQueryStatistics(ctx context.Context, project 
 }
 
 type MySqlserviceQueryStatisticsIn struct {
-	Limit   *int   `json:"limit,omitempty"`
-	Offset  *int   `json:"offset,omitempty"`
-	OrderBy string `json:"order_by,omitempty"`
+	Limit   *int    `json:"limit,omitempty"`
+	Offset  *int    `json:"offset,omitempty"`
+	OrderBy *string `json:"order_by,omitempty"`
 }
 type QueryOut struct {
 	AvgTimerWait            *float64 `json:"avg_timer_wait,omitempty"`
 	CountStar               *float64 `json:"count_star,omitempty"`
-	Digest                  string   `json:"digest,omitempty"`
-	DigestText              string   `json:"digest_text,omitempty"`
-	FirstSeen               string   `json:"first_seen,omitempty"`
-	LastSeen                string   `json:"last_seen,omitempty"`
+	Digest                  *string  `json:"digest,omitempty"`
+	DigestText              *string  `json:"digest_text,omitempty"`
+	FirstSeen               *string  `json:"first_seen,omitempty"`
+	LastSeen                *string  `json:"last_seen,omitempty"`
 	MaxTimerWait            *float64 `json:"max_timer_wait,omitempty"`
 	MinTimerWait            *float64 `json:"min_timer_wait,omitempty"`
 	Quantile95              *float64 `json:"quantile_95,omitempty"`
 	Quantile99              *float64 `json:"quantile_99,omitempty"`
 	Quantile999             *float64 `json:"quantile_999,omitempty"`
-	QuerySampleSeen         string   `json:"query_sample_seen,omitempty"`
-	QuerySampleText         string   `json:"query_sample_text,omitempty"`
-	QuerySampleTimerWait    string   `json:"query_sample_timer_wait,omitempty"`
-	SchemaName              string   `json:"schema_name,omitempty"`
+	QuerySampleSeen         *string  `json:"query_sample_seen,omitempty"`
+	QuerySampleText         *string  `json:"query_sample_text,omitempty"`
+	QuerySampleTimerWait    *string  `json:"query_sample_timer_wait,omitempty"`
+	SchemaName              *string  `json:"schema_name,omitempty"`
 	SumCreatedTmpDiskTables *float64 `json:"sum_created_tmp_disk_tables,omitempty"`
 	SumCreatedTmpTables     *float64 `json:"sum_created_tmp_tables,omitempty"`
 	SumErrors               *float64 `json:"sum_errors,omitempty"`

--- a/handler/opensearch/opensearch.go
+++ b/handler/opensearch/opensearch.go
@@ -231,9 +231,9 @@ func PermissionTypeChoices() []string {
 }
 
 type ReplicationOut struct {
-	LeaderIndex   string `json:"leader_index,omitempty"`
-	LeaderProject string `json:"leader_project,omitempty"`
-	LeaderService string `json:"leader_service,omitempty"`
+	LeaderIndex   *string `json:"leader_index,omitempty"`
+	LeaderProject *string `json:"leader_project,omitempty"`
+	LeaderService *string `json:"leader_service,omitempty"`
 }
 type RuleIn struct {
 	Index      string         `json:"index"`

--- a/handler/organization/organization.go
+++ b/handler/organization/organization.go
@@ -226,7 +226,7 @@ type OrganizationAuthenticationConfigUpdateOut struct {
 type OrganizationGetOut struct {
 	AccountId                    string    `json:"account_id"`
 	CreateTime                   time.Time `json:"create_time"`
-	DefaultGovernanceUserGroupId string    `json:"default_governance_user_group_id,omitempty"`
+	DefaultGovernanceUserGroupId *string   `json:"default_governance_user_group_id,omitempty"`
 	OrganizationId               string    `json:"organization_id"`
 	OrganizationName             string    `json:"organization_name"`
 	Tier                         TierType  `json:"tier"`
@@ -235,22 +235,22 @@ type OrganizationGetOut struct {
 type OrganizationOut struct {
 	AccountId                    string    `json:"account_id"`
 	CreateTime                   time.Time `json:"create_time"`
-	DefaultGovernanceUserGroupId string    `json:"default_governance_user_group_id,omitempty"`
+	DefaultGovernanceUserGroupId *string   `json:"default_governance_user_group_id,omitempty"`
 	OrganizationId               string    `json:"organization_id"`
 	OrganizationName             string    `json:"organization_name"`
 	Tier                         TierType  `json:"tier"`
 	UpdateTime                   time.Time `json:"update_time"`
 }
 type OrganizationUpdateIn struct {
-	DefaultGovernanceUserGroupId string   `json:"default_governance_user_group_id,omitempty"`
+	DefaultGovernanceUserGroupId *string  `json:"default_governance_user_group_id,omitempty"`
 	KafkaGovernanceEnabled       *bool    `json:"kafka_governance_enabled,omitempty"`
-	Name                         string   `json:"name,omitempty"`
+	Name                         *string  `json:"name,omitempty"`
 	Tier                         TierType `json:"tier,omitempty"`
 }
 type OrganizationUpdateOut struct {
 	AccountId                    string    `json:"account_id"`
 	CreateTime                   time.Time `json:"create_time"`
-	DefaultGovernanceUserGroupId string    `json:"default_governance_user_group_id,omitempty"`
+	DefaultGovernanceUserGroupId *string   `json:"default_governance_user_group_id,omitempty"`
 	OrganizationId               string    `json:"organization_id"`
 	OrganizationName             string    `json:"organization_name"`
 	Tier                         TierType  `json:"tier"`
@@ -269,13 +269,13 @@ func TierTypeChoices() []string {
 
 type UserOrganizationCreateIn struct {
 	OrganizationName      string   `json:"organization_name"`
-	PrimaryBillingGroupId string   `json:"primary_billing_group_id,omitempty"`
+	PrimaryBillingGroupId *string  `json:"primary_billing_group_id,omitempty"`
 	Tier                  TierType `json:"tier"`
 }
 type UserOrganizationCreateOut struct {
 	AccountId                    string    `json:"account_id"`
 	CreateTime                   time.Time `json:"create_time"`
-	DefaultGovernanceUserGroupId string    `json:"default_governance_user_group_id,omitempty"`
+	DefaultGovernanceUserGroupId *string   `json:"default_governance_user_group_id,omitempty"`
 	OrganizationId               string    `json:"organization_id"`
 	OrganizationName             string    `json:"organization_name"`
 	Tier                         TierType  `json:"tier"`

--- a/handler/organizationuser/organizationuser.go
+++ b/handler/organizationuser/organizationuser.go
@@ -206,14 +206,14 @@ func ActionTypeChoices() []string {
 type AuthenticationMethodOut struct {
 	IsEnabled2Fa     *bool      `json:"is_enabled_2fa,omitempty"`
 	LastUsedTime     *time.Time `json:"last_used_time,omitempty"`
-	LocalProviderId  string     `json:"local_provider_id,omitempty"`
-	MethodId         string     `json:"method_id,omitempty"`
-	Name             string     `json:"name,omitempty"`
-	OrganizationId   string     `json:"organization_id,omitempty"`
+	LocalProviderId  *string    `json:"local_provider_id,omitempty"`
+	MethodId         *string    `json:"method_id,omitempty"`
+	Name             *string    `json:"name,omitempty"`
+	OrganizationId   *string    `json:"organization_id,omitempty"`
 	RemoteProviderId string     `json:"remote_provider_id"`
-	Type             string     `json:"type,omitempty"`
-	UserEmail        string     `json:"user_email,omitempty"`
-	UserId           string     `json:"user_id,omitempty"`
+	Type             *string    `json:"type,omitempty"`
+	UserEmail        *string    `json:"user_email,omitempty"`
+	UserId           *string    `json:"user_id,omitempty"`
 }
 type InvitationOut struct {
 	CreateTime time.Time `json:"create_time"`
@@ -247,12 +247,12 @@ func OrganizationUserStateTypeChoices() []string {
 }
 
 type OrganizationUserUpdateIn struct {
-	City         string                    `json:"city,omitempty"`
-	Country      string                    `json:"country,omitempty"`
-	Department   string                    `json:"department,omitempty"`
+	City         *string                   `json:"city,omitempty"`
+	Country      *string                   `json:"country,omitempty"`
+	Department   *string                   `json:"department,omitempty"`
 	IsSuperAdmin *bool                     `json:"is_super_admin,omitempty"`
-	JobTitle     string                    `json:"job_title,omitempty"`
-	RealName     string                    `json:"real_name,omitempty"`
+	JobTitle     *string                   `json:"job_title,omitempty"`
+	RealName     *string                   `json:"real_name,omitempty"`
 	State        OrganizationUserStateType `json:"state,omitempty"`
 }
 type OrganizationUserUpdateOut struct {
@@ -270,14 +270,14 @@ type TokenOut struct {
 	TokenPrefix   string    `json:"token_prefix"`
 }
 type UserInfoOut struct {
-	City                   string    `json:"city,omitempty"`
-	Country                string    `json:"country,omitempty"`
+	City                   *string   `json:"city,omitempty"`
+	Country                *string   `json:"country,omitempty"`
 	CreateTime             time.Time `json:"create_time"`
-	Department             string    `json:"department,omitempty"`
+	Department             *string   `json:"department,omitempty"`
 	IsApplicationUser      bool      `json:"is_application_user"`
-	JobTitle               string    `json:"job_title,omitempty"`
+	JobTitle               *string   `json:"job_title,omitempty"`
 	ManagedByScim          bool      `json:"managed_by_scim"`
-	ManagingOrganizationId string    `json:"managing_organization_id,omitempty"`
+	ManagingOrganizationId *string   `json:"managing_organization_id,omitempty"`
 	RealName               string    `json:"real_name"`
 	State                  string    `json:"state"`
 	UserEmail              string    `json:"user_email"`

--- a/handler/postgresql/postgresql.go
+++ b/handler/postgresql/postgresql.go
@@ -117,9 +117,9 @@ type PgOut struct {
 	Version    string         `json:"version"`
 }
 type PgserviceQueryStatisticsIn struct {
-	Limit   *int   `json:"limit,omitempty"`
-	Offset  *int   `json:"offset,omitempty"`
-	OrderBy string `json:"order_by,omitempty"`
+	Limit   *int    `json:"limit,omitempty"`
+	Offset  *int    `json:"offset,omitempty"`
+	OrderBy *string `json:"order_by,omitempty"`
 }
 type PoolModeType string
 
@@ -137,7 +137,7 @@ type QueryOut struct {
 	BlkReadTime       *float64 `json:"blk_read_time,omitempty"`
 	BlkWriteTime      *float64 `json:"blk_write_time,omitempty"`
 	Calls             *float64 `json:"calls,omitempty"`
-	DatabaseName      string   `json:"database_name,omitempty"`
+	DatabaseName      *string  `json:"database_name,omitempty"`
 	LocalBlksDirtied  *float64 `json:"local_blks_dirtied,omitempty"`
 	LocalBlksHit      *float64 `json:"local_blks_hit,omitempty"`
 	LocalBlksRead     *float64 `json:"local_blks_read,omitempty"`
@@ -151,7 +151,7 @@ type QueryOut struct {
 	MinExecTime       *float64 `json:"min_exec_time,omitempty"`
 	MinPlanTime       *float64 `json:"min_plan_time,omitempty"`
 	MinTime           *float64 `json:"min_time,omitempty"`
-	Query             string   `json:"query,omitempty"`
+	Query             *string  `json:"query,omitempty"`
 	Queryid           *float64 `json:"queryid,omitempty"`
 	Rows              *float64 `json:"rows,omitempty"`
 	SharedBlksDirtied *float64 `json:"shared_blks_dirtied,omitempty"`
@@ -166,8 +166,8 @@ type QueryOut struct {
 	TotalExecTime     *float64 `json:"total_exec_time,omitempty"`
 	TotalPlanTime     *float64 `json:"total_plan_time,omitempty"`
 	TotalTime         *float64 `json:"total_time,omitempty"`
-	UserName          string   `json:"user_name,omitempty"`
-	WalBytes          string   `json:"wal_bytes,omitempty"`
+	UserName          *string  `json:"user_name,omitempty"`
+	WalBytes          *string  `json:"wal_bytes,omitempty"`
 	WalFpi            *float64 `json:"wal_fpi,omitempty"`
 	WalRecords        *float64 `json:"wal_records,omitempty"`
 }
@@ -176,13 +176,13 @@ type ServicePgbouncerCreateIn struct {
 	PoolMode PoolModeType `json:"pool_mode,omitempty"`
 	PoolName string       `json:"pool_name"`
 	PoolSize *int         `json:"pool_size,omitempty"`
-	Username string       `json:"username,omitempty"`
+	Username *string      `json:"username,omitempty"`
 }
 type ServicePgbouncerUpdateIn struct {
-	Database string       `json:"database,omitempty"`
+	Database *string      `json:"database,omitempty"`
 	PoolMode PoolModeType `json:"pool_mode,omitempty"`
 	PoolSize *int         `json:"pool_size,omitempty"`
-	Username string       `json:"username,omitempty"`
+	Username *string      `json:"username,omitempty"`
 }
 type pgAvailableExtensionsOut struct {
 	Pg []PgOut `json:"pg,omitempty"`

--- a/handler/privatelink/privatelink.go
+++ b/handler/privatelink/privatelink.go
@@ -260,13 +260,13 @@ func (h *PrivatelinkHandler) ServicePrivatelinkAzureUpdate(ctx context.Context, 
 
 type ConnectionOut struct {
 	DnsName                 string              `json:"dns_name"`
-	PrivatelinkConnectionId string              `json:"privatelink_connection_id,omitempty"`
+	PrivatelinkConnectionId *string             `json:"privatelink_connection_id,omitempty"`
 	State                   ConnectionStateType `json:"state"`
 	VpcEndpointId           string              `json:"vpc_endpoint_id"`
 }
 type ConnectionOutAlt struct {
 	PrivateEndpointId       string              `json:"private_endpoint_id"`
-	PrivatelinkConnectionId string              `json:"privatelink_connection_id,omitempty"`
+	PrivatelinkConnectionId *string             `json:"privatelink_connection_id,omitempty"`
 	State                   ConnectionStateType `json:"state"`
 	UserIpAddress           string              `json:"user_ip_address"`
 }
@@ -291,8 +291,8 @@ type ServicePrivatelinkAwscreateIn struct {
 	Principals []string `json:"principals"`
 }
 type ServicePrivatelinkAwscreateOut struct {
-	AwsServiceId   string                               `json:"aws_service_id,omitempty"`
-	AwsServiceName string                               `json:"aws_service_name,omitempty"`
+	AwsServiceId   *string                              `json:"aws_service_id,omitempty"`
+	AwsServiceName *string                              `json:"aws_service_name,omitempty"`
 	Principals     []string                             `json:"principals"`
 	State          ServicePrivatelinkAwscreateStateType `json:"state"`
 }
@@ -309,8 +309,8 @@ func ServicePrivatelinkAwscreateStateTypeChoices() []string {
 }
 
 type ServicePrivatelinkAwsdeleteOut struct {
-	AwsServiceId   string                               `json:"aws_service_id,omitempty"`
-	AwsServiceName string                               `json:"aws_service_name,omitempty"`
+	AwsServiceId   *string                              `json:"aws_service_id,omitempty"`
+	AwsServiceName *string                              `json:"aws_service_name,omitempty"`
 	Principals     []string                             `json:"principals"`
 	State          ServicePrivatelinkAwsdeleteStateType `json:"state"`
 }
@@ -327,8 +327,8 @@ func ServicePrivatelinkAwsdeleteStateTypeChoices() []string {
 }
 
 type ServicePrivatelinkAwsgetOut struct {
-	AwsServiceId   string                            `json:"aws_service_id,omitempty"`
-	AwsServiceName string                            `json:"aws_service_name,omitempty"`
+	AwsServiceId   *string                           `json:"aws_service_id,omitempty"`
+	AwsServiceName *string                           `json:"aws_service_name,omitempty"`
 	Principals     []string                          `json:"principals"`
 	State          ServicePrivatelinkAwsgetStateType `json:"state"`
 }
@@ -348,8 +348,8 @@ type ServicePrivatelinkAwsupdateIn struct {
 	Principals []string `json:"principals"`
 }
 type ServicePrivatelinkAwsupdateOut struct {
-	AwsServiceId   string                               `json:"aws_service_id,omitempty"`
-	AwsServiceName string                               `json:"aws_service_name,omitempty"`
+	AwsServiceId   *string                              `json:"aws_service_id,omitempty"`
+	AwsServiceName *string                              `json:"aws_service_name,omitempty"`
 	Principals     []string                             `json:"principals"`
 	State          ServicePrivatelinkAwsupdateStateType `json:"state"`
 }
@@ -367,7 +367,7 @@ func ServicePrivatelinkAwsupdateStateTypeChoices() []string {
 
 type ServicePrivatelinkAzureConnectionApprovalOut struct {
 	PrivateEndpointId       string                                             `json:"private_endpoint_id"`
-	PrivatelinkConnectionId string                                             `json:"privatelink_connection_id,omitempty"`
+	PrivatelinkConnectionId *string                                            `json:"privatelink_connection_id,omitempty"`
 	State                   ServicePrivatelinkAzureConnectionApprovalStateType `json:"state"`
 	UserIpAddress           string                                             `json:"user_ip_address"`
 }
@@ -402,7 +402,7 @@ type ServicePrivatelinkAzureConnectionUpdateIn struct {
 }
 type ServicePrivatelinkAzureConnectionUpdateOut struct {
 	PrivateEndpointId       string                                     `json:"private_endpoint_id"`
-	PrivatelinkConnectionId string                                     `json:"privatelink_connection_id,omitempty"`
+	PrivatelinkConnectionId *string                                    `json:"privatelink_connection_id,omitempty"`
 	State                   ServicePrivatelinkAzureConnectionStateType `json:"state"`
 	UserIpAddress           string                                     `json:"user_ip_address"`
 }
@@ -410,20 +410,20 @@ type ServicePrivatelinkAzureCreateIn struct {
 	UserSubscriptionIds []string `json:"user_subscription_ids"`
 }
 type ServicePrivatelinkAzureCreateOut struct {
-	AzureServiceAlias   string                           `json:"azure_service_alias,omitempty"`
-	AzureServiceId      string                           `json:"azure_service_id,omitempty"`
+	AzureServiceAlias   *string                          `json:"azure_service_alias,omitempty"`
+	AzureServiceId      *string                          `json:"azure_service_id,omitempty"`
 	State               ServicePrivatelinkAzureStateType `json:"state"`
 	UserSubscriptionIds []string                         `json:"user_subscription_ids"`
 }
 type ServicePrivatelinkAzureDeleteOut struct {
-	AzureServiceAlias   string                           `json:"azure_service_alias,omitempty"`
-	AzureServiceId      string                           `json:"azure_service_id,omitempty"`
+	AzureServiceAlias   *string                          `json:"azure_service_alias,omitempty"`
+	AzureServiceId      *string                          `json:"azure_service_id,omitempty"`
 	State               ServicePrivatelinkAzureStateType `json:"state"`
 	UserSubscriptionIds []string                         `json:"user_subscription_ids"`
 }
 type ServicePrivatelinkAzureGetOut struct {
-	AzureServiceAlias   string                           `json:"azure_service_alias,omitempty"`
-	AzureServiceId      string                           `json:"azure_service_id,omitempty"`
+	AzureServiceAlias   *string                          `json:"azure_service_alias,omitempty"`
+	AzureServiceId      *string                          `json:"azure_service_id,omitempty"`
 	State               ServicePrivatelinkAzureStateType `json:"state"`
 	UserSubscriptionIds []string                         `json:"user_subscription_ids"`
 }
@@ -443,8 +443,8 @@ type ServicePrivatelinkAzureUpdateIn struct {
 	UserSubscriptionIds []string `json:"user_subscription_ids"`
 }
 type ServicePrivatelinkAzureUpdateOut struct {
-	AzureServiceAlias   string                           `json:"azure_service_alias,omitempty"`
-	AzureServiceId      string                           `json:"azure_service_id,omitempty"`
+	AzureServiceAlias   *string                          `json:"azure_service_alias,omitempty"`
+	AzureServiceId      *string                          `json:"azure_service_id,omitempty"`
 	State               ServicePrivatelinkAzureStateType `json:"state"`
 	UserSubscriptionIds []string                         `json:"user_subscription_ids"`
 }

--- a/handler/project/project.go
+++ b/handler/project/project.go
@@ -332,10 +332,10 @@ func (h *ProjectHandler) ProjectUserUpdate(ctx context.Context, project string, 
 type AlertOut struct {
 	CreateTime  time.Time `json:"create_time"`
 	Event       string    `json:"event"`
-	NodeName    string    `json:"node_name,omitempty"`
+	NodeName    *string   `json:"node_name,omitempty"`
 	ProjectName string    `json:"project_name"`
-	ServiceName string    `json:"service_name,omitempty"`
-	ServiceType string    `json:"service_type,omitempty"`
+	ServiceName *string   `json:"service_name,omitempty"`
+	ServiceType *string   `json:"service_type,omitempty"`
 	Severity    string    `json:"severity"`
 }
 type AnyType string
@@ -434,93 +434,93 @@ type PrivatelinkAvailabilityOut struct {
 	PriceUsd  string `json:"price_usd"`
 }
 type ProjectCreateIn struct {
-	AccountId                    string              `json:"account_id,omitempty"`
+	AccountId                    *string             `json:"account_id,omitempty"`
 	AddAccountOwnersAdminAccess  *bool               `json:"add_account_owners_admin_access,omitempty"`
 	AddressLines                 *[]string           `json:"address_lines,omitempty"`
 	BasePort                     *int                `json:"base_port,omitempty"`
-	BillingAddress               string              `json:"billing_address,omitempty"`
+	BillingAddress               *string             `json:"billing_address,omitempty"`
 	BillingCurrency              BillingCurrencyType `json:"billing_currency,omitempty"`
 	BillingEmails                *[]BillingEmailIn   `json:"billing_emails,omitempty"`
-	BillingExtraText             string              `json:"billing_extra_text,omitempty"`
-	BillingGroupId               string              `json:"billing_group_id,omitempty"`
-	CardId                       string              `json:"card_id,omitempty"`
-	City                         string              `json:"city,omitempty"`
-	Cloud                        string              `json:"cloud,omitempty"`
-	Company                      string              `json:"company,omitempty"`
-	CopyFromProject              string              `json:"copy_from_project,omitempty"`
+	BillingExtraText             *string             `json:"billing_extra_text,omitempty"`
+	BillingGroupId               *string             `json:"billing_group_id,omitempty"`
+	CardId                       *string             `json:"card_id,omitempty"`
+	City                         *string             `json:"city,omitempty"`
+	Cloud                        *string             `json:"cloud,omitempty"`
+	Company                      *string             `json:"company,omitempty"`
+	CopyFromProject              *string             `json:"copy_from_project,omitempty"`
 	CopyTags                     *bool               `json:"copy_tags,omitempty"`
-	CountryCode                  string              `json:"country_code,omitempty"`
+	CountryCode                  *string             `json:"country_code,omitempty"`
 	Project                      string              `json:"project"`
-	State                        string              `json:"state,omitempty"`
+	State                        *string             `json:"state,omitempty"`
 	Tags                         *map[string]string  `json:"tags,omitempty"`
 	TechEmails                   *[]TechEmailIn      `json:"tech_emails,omitempty"`
 	UseSourceProjectBillingGroup *bool               `json:"use_source_project_billing_group,omitempty"`
-	VatId                        string              `json:"vat_id,omitempty"`
-	ZipCode                      string              `json:"zip_code,omitempty"`
+	VatId                        *string             `json:"vat_id,omitempty"`
+	ZipCode                      *string             `json:"zip_code,omitempty"`
 }
 type ProjectCreateOut struct {
 	AccountId             string                 `json:"account_id"`
-	AccountName           string                 `json:"account_name,omitempty"`
+	AccountName           *string                `json:"account_name,omitempty"`
 	AddressLines          []string               `json:"address_lines,omitempty"`
-	AvailableCredits      string                 `json:"available_credits,omitempty"`
+	AvailableCredits      *string                `json:"available_credits,omitempty"`
 	BillingAddress        string                 `json:"billing_address"`
 	BillingCurrency       BillingCurrencyType    `json:"billing_currency,omitempty"`
 	BillingEmails         []BillingEmailOut      `json:"billing_emails"`
-	BillingExtraText      string                 `json:"billing_extra_text,omitempty"`
+	BillingExtraText      *string                `json:"billing_extra_text,omitempty"`
 	BillingGroupId        string                 `json:"billing_group_id"`
 	BillingGroupName      string                 `json:"billing_group_name"`
 	CardInfo              *CardInfoOut           `json:"card_info,omitempty"`
-	City                  string                 `json:"city,omitempty"`
-	Company               string                 `json:"company,omitempty"`
+	City                  *string                `json:"city,omitempty"`
+	Company               *string                `json:"company,omitempty"`
 	Country               string                 `json:"country"`
 	CountryCode           string                 `json:"country_code"`
 	DefaultCloud          string                 `json:"default_cloud"`
 	EndOfLifeExtension    *EndOfLifeExtensionOut `json:"end_of_life_extension,omitempty"`
 	EstimatedBalance      string                 `json:"estimated_balance"`
-	EstimatedBalanceLocal string                 `json:"estimated_balance_local,omitempty"`
+	EstimatedBalanceLocal *string                `json:"estimated_balance_local,omitempty"`
 	Features              map[string]any         `json:"features,omitempty"`
 	OrganizationId        string                 `json:"organization_id"`
 	PaymentMethod         string                 `json:"payment_method"`
 	ProjectName           string                 `json:"project_name"`
-	State                 string                 `json:"state,omitempty"`
+	State                 *string                `json:"state,omitempty"`
 	Tags                  map[string]string      `json:"tags,omitempty"`
 	TechEmails            []TechEmailOut         `json:"tech_emails,omitempty"`
-	TenantId              string                 `json:"tenant_id,omitempty"`
+	TenantId              *string                `json:"tenant_id,omitempty"`
 	TrialExpirationTime   *time.Time             `json:"trial_expiration_time,omitempty"`
 	VatId                 string                 `json:"vat_id"`
-	ZipCode               string                 `json:"zip_code,omitempty"`
+	ZipCode               *string                `json:"zip_code,omitempty"`
 }
 type ProjectGetOut struct {
 	AccountId             string                 `json:"account_id"`
-	AccountName           string                 `json:"account_name,omitempty"`
+	AccountName           *string                `json:"account_name,omitempty"`
 	AddressLines          []string               `json:"address_lines,omitempty"`
-	AvailableCredits      string                 `json:"available_credits,omitempty"`
+	AvailableCredits      *string                `json:"available_credits,omitempty"`
 	BillingAddress        string                 `json:"billing_address"`
 	BillingCurrency       BillingCurrencyType    `json:"billing_currency,omitempty"`
 	BillingEmails         []BillingEmailOut      `json:"billing_emails"`
-	BillingExtraText      string                 `json:"billing_extra_text,omitempty"`
+	BillingExtraText      *string                `json:"billing_extra_text,omitempty"`
 	BillingGroupId        string                 `json:"billing_group_id"`
 	BillingGroupName      string                 `json:"billing_group_name"`
 	CardInfo              *CardInfoOut           `json:"card_info,omitempty"`
-	City                  string                 `json:"city,omitempty"`
-	Company               string                 `json:"company,omitempty"`
+	City                  *string                `json:"city,omitempty"`
+	Company               *string                `json:"company,omitempty"`
 	Country               string                 `json:"country"`
 	CountryCode           string                 `json:"country_code"`
 	DefaultCloud          string                 `json:"default_cloud"`
 	EndOfLifeExtension    *EndOfLifeExtensionOut `json:"end_of_life_extension,omitempty"`
 	EstimatedBalance      string                 `json:"estimated_balance"`
-	EstimatedBalanceLocal string                 `json:"estimated_balance_local,omitempty"`
+	EstimatedBalanceLocal *string                `json:"estimated_balance_local,omitempty"`
 	Features              map[string]any         `json:"features,omitempty"`
 	OrganizationId        string                 `json:"organization_id"`
 	PaymentMethod         string                 `json:"payment_method"`
 	ProjectName           string                 `json:"project_name"`
-	State                 string                 `json:"state,omitempty"`
+	State                 *string                `json:"state,omitempty"`
 	Tags                  map[string]string      `json:"tags,omitempty"`
 	TechEmails            []TechEmailOut         `json:"tech_emails,omitempty"`
-	TenantId              string                 `json:"tenant_id,omitempty"`
+	TenantId              *string                `json:"tenant_id,omitempty"`
 	TrialExpirationTime   *time.Time             `json:"trial_expiration_time,omitempty"`
 	VatId                 string                 `json:"vat_id"`
-	ZipCode               string                 `json:"zip_code,omitempty"`
+	ZipCode               *string                `json:"zip_code,omitempty"`
 }
 type ProjectInviteAcceptOut struct {
 	UserEmail string `json:"user_email"`
@@ -542,35 +542,35 @@ type ProjectMembershipsOut struct {
 }
 type ProjectOut struct {
 	AccountId             string                 `json:"account_id"`
-	AccountName           string                 `json:"account_name,omitempty"`
+	AccountName           *string                `json:"account_name,omitempty"`
 	AddressLines          []string               `json:"address_lines,omitempty"`
-	AvailableCredits      string                 `json:"available_credits,omitempty"`
+	AvailableCredits      *string                `json:"available_credits,omitempty"`
 	BillingAddress        string                 `json:"billing_address"`
 	BillingCurrency       BillingCurrencyType    `json:"billing_currency,omitempty"`
 	BillingEmails         []BillingEmailOut      `json:"billing_emails"`
-	BillingExtraText      string                 `json:"billing_extra_text,omitempty"`
+	BillingExtraText      *string                `json:"billing_extra_text,omitempty"`
 	BillingGroupId        string                 `json:"billing_group_id"`
 	BillingGroupName      string                 `json:"billing_group_name"`
 	CardInfo              *CardInfoOut           `json:"card_info,omitempty"`
-	City                  string                 `json:"city,omitempty"`
-	Company               string                 `json:"company,omitempty"`
+	City                  *string                `json:"city,omitempty"`
+	Company               *string                `json:"company,omitempty"`
 	Country               string                 `json:"country"`
 	CountryCode           string                 `json:"country_code"`
 	DefaultCloud          string                 `json:"default_cloud"`
 	EndOfLifeExtension    *EndOfLifeExtensionOut `json:"end_of_life_extension,omitempty"`
 	EstimatedBalance      string                 `json:"estimated_balance"`
-	EstimatedBalanceLocal string                 `json:"estimated_balance_local,omitempty"`
+	EstimatedBalanceLocal *string                `json:"estimated_balance_local,omitempty"`
 	Features              map[string]any         `json:"features,omitempty"`
 	OrganizationId        string                 `json:"organization_id"`
 	PaymentMethod         string                 `json:"payment_method"`
 	ProjectName           string                 `json:"project_name"`
-	State                 string                 `json:"state,omitempty"`
+	State                 *string                `json:"state,omitempty"`
 	Tags                  map[string]string      `json:"tags,omitempty"`
 	TechEmails            []TechEmailOut         `json:"tech_emails,omitempty"`
-	TenantId              string                 `json:"tenant_id,omitempty"`
+	TenantId              *string                `json:"tenant_id,omitempty"`
 	TrialExpirationTime   *time.Time             `json:"trial_expiration_time,omitempty"`
 	VatId                 string                 `json:"vat_id"`
-	ZipCode               string                 `json:"zip_code,omitempty"`
+	ZipCode               *string                `json:"zip_code,omitempty"`
 }
 type ProjectTagsReplaceIn struct {
 	Tags map[string]string `json:"tags"`
@@ -579,57 +579,57 @@ type ProjectTagsUpdateIn struct {
 	Tags map[string]string `json:"tags"`
 }
 type ProjectUpdateIn struct {
-	AccountId                   string              `json:"account_id,omitempty"`
+	AccountId                   *string             `json:"account_id,omitempty"`
 	AddAccountOwnersAdminAccess *bool               `json:"add_account_owners_admin_access,omitempty"`
 	AddressLines                *[]string           `json:"address_lines,omitempty"`
-	BillingAddress              string              `json:"billing_address,omitempty"`
+	BillingAddress              *string             `json:"billing_address,omitempty"`
 	BillingCurrency             BillingCurrencyType `json:"billing_currency,omitempty"`
 	BillingEmails               *[]BillingEmailIn   `json:"billing_emails,omitempty"`
-	BillingExtraText            string              `json:"billing_extra_text,omitempty"`
-	BillingGroupId              string              `json:"billing_group_id,omitempty"`
-	CardId                      string              `json:"card_id,omitempty"`
-	City                        string              `json:"city,omitempty"`
-	Cloud                       string              `json:"cloud,omitempty"`
-	Company                     string              `json:"company,omitempty"`
-	CountryCode                 string              `json:"country_code,omitempty"`
-	ProjectName                 string              `json:"project_name,omitempty"`
-	State                       string              `json:"state,omitempty"`
+	BillingExtraText            *string             `json:"billing_extra_text,omitempty"`
+	BillingGroupId              *string             `json:"billing_group_id,omitempty"`
+	CardId                      *string             `json:"card_id,omitempty"`
+	City                        *string             `json:"city,omitempty"`
+	Cloud                       *string             `json:"cloud,omitempty"`
+	Company                     *string             `json:"company,omitempty"`
+	CountryCode                 *string             `json:"country_code,omitempty"`
+	ProjectName                 *string             `json:"project_name,omitempty"`
+	State                       *string             `json:"state,omitempty"`
 	Tags                        *map[string]string  `json:"tags,omitempty"`
 	TechEmails                  *[]TechEmailIn      `json:"tech_emails,omitempty"`
-	VatId                       string              `json:"vat_id,omitempty"`
-	ZipCode                     string              `json:"zip_code,omitempty"`
+	VatId                       *string             `json:"vat_id,omitempty"`
+	ZipCode                     *string             `json:"zip_code,omitempty"`
 }
 type ProjectUpdateOut struct {
 	AccountId             string                 `json:"account_id"`
-	AccountName           string                 `json:"account_name,omitempty"`
+	AccountName           *string                `json:"account_name,omitempty"`
 	AddressLines          []string               `json:"address_lines,omitempty"`
-	AvailableCredits      string                 `json:"available_credits,omitempty"`
+	AvailableCredits      *string                `json:"available_credits,omitempty"`
 	BillingAddress        string                 `json:"billing_address"`
 	BillingCurrency       BillingCurrencyType    `json:"billing_currency,omitempty"`
 	BillingEmails         []BillingEmailOut      `json:"billing_emails"`
-	BillingExtraText      string                 `json:"billing_extra_text,omitempty"`
+	BillingExtraText      *string                `json:"billing_extra_text,omitempty"`
 	BillingGroupId        string                 `json:"billing_group_id"`
 	BillingGroupName      string                 `json:"billing_group_name"`
 	CardInfo              *CardInfoOut           `json:"card_info,omitempty"`
-	City                  string                 `json:"city,omitempty"`
-	Company               string                 `json:"company,omitempty"`
+	City                  *string                `json:"city,omitempty"`
+	Company               *string                `json:"company,omitempty"`
 	Country               string                 `json:"country"`
 	CountryCode           string                 `json:"country_code"`
 	DefaultCloud          string                 `json:"default_cloud"`
 	EndOfLifeExtension    *EndOfLifeExtensionOut `json:"end_of_life_extension,omitempty"`
 	EstimatedBalance      string                 `json:"estimated_balance"`
-	EstimatedBalanceLocal string                 `json:"estimated_balance_local,omitempty"`
+	EstimatedBalanceLocal *string                `json:"estimated_balance_local,omitempty"`
 	Features              map[string]any         `json:"features,omitempty"`
 	OrganizationId        string                 `json:"organization_id"`
 	PaymentMethod         string                 `json:"payment_method"`
 	ProjectName           string                 `json:"project_name"`
-	State                 string                 `json:"state,omitempty"`
+	State                 *string                `json:"state,omitempty"`
 	Tags                  map[string]string      `json:"tags,omitempty"`
 	TechEmails            []TechEmailOut         `json:"tech_emails,omitempty"`
-	TenantId              string                 `json:"tenant_id,omitempty"`
+	TenantId              *string                `json:"tenant_id,omitempty"`
 	TrialExpirationTime   *time.Time             `json:"trial_expiration_time,omitempty"`
 	VatId                 string                 `json:"vat_id"`
-	ZipCode               string                 `json:"zip_code,omitempty"`
+	ZipCode               *string                `json:"zip_code,omitempty"`
 }
 type ProjectUserListOut struct {
 	GroupUsers  []GroupUserOut  `json:"group_users"`
@@ -650,7 +650,7 @@ type UserOut struct {
 	BillingContact bool       `json:"billing_contact"`
 	CreateTime     time.Time  `json:"create_time"`
 	MemberType     MemberType `json:"member_type"`
-	RealName       string     `json:"real_name,omitempty"`
+	RealName       *string    `json:"real_name,omitempty"`
 	TeamId         string     `json:"team_id"`
 	TeamName       string     `json:"team_name"`
 	UserEmail      string     `json:"user_email"`

--- a/handler/projectbilling/projectbilling.go
+++ b/handler/projectbilling/projectbilling.go
@@ -109,12 +109,12 @@ func BillingGroupStateTypeChoices() []string {
 }
 
 type CreditOut struct {
-	Code           string     `json:"code,omitempty"`
+	Code           *string    `json:"code,omitempty"`
 	ExpireTime     *time.Time `json:"expire_time,omitempty"`
-	RemainingValue string     `json:"remaining_value,omitempty"`
+	RemainingValue *string    `json:"remaining_value,omitempty"`
 	StartTime      *time.Time `json:"start_time,omitempty"`
 	Type           CreditType `json:"type,omitempty"`
-	Value          string     `json:"value,omitempty"`
+	Value          *string    `json:"value,omitempty"`
 }
 type CreditType string
 
@@ -164,7 +164,7 @@ type InvoiceGetOut struct {
 	BillingGroupName  string    `json:"billing_group_name"`
 	BillingGroupState string    `json:"billing_group_state"`
 	Currency          string    `json:"currency"`
-	DownloadCookie    string    `json:"download_cookie,omitempty"`
+	DownloadCookie    *string   `json:"download_cookie,omitempty"`
 	GeneratedAt       time.Time `json:"generated_at"`
 	InvoiceNumber     string    `json:"invoice_number"`
 	PeriodBegin       string    `json:"period_begin"`
@@ -214,12 +214,12 @@ type ProjectCreditsClaimIn struct {
 	Code string `json:"code"`
 }
 type ProjectCreditsClaimOut struct {
-	Code           string     `json:"code,omitempty"`
+	Code           *string    `json:"code,omitempty"`
 	ExpireTime     *time.Time `json:"expire_time,omitempty"`
-	RemainingValue string     `json:"remaining_value,omitempty"`
+	RemainingValue *string    `json:"remaining_value,omitempty"`
 	StartTime      *time.Time `json:"start_time,omitempty"`
 	Type           CreditType `json:"type,omitempty"`
-	Value          string     `json:"value,omitempty"`
+	Value          *string    `json:"value,omitempty"`
 }
 type invoiceGetOut struct {
 	Invoice InvoiceGetOut `json:"invoice"`

--- a/handler/service/service.go
+++ b/handler/service/service.go
@@ -94,7 +94,7 @@ type Handler interface {
 	// ServiceEnableWrites temporarily enable writes for a service in read-only mode. Will only work if disk usage is lower than 99.0%
 	// POST /v1/project/{project}/service/{service_name}/enable-writes
 	// https://api.aiven.io/doc/#tag/Service/operation/ServiceEnableWrites
-	ServiceEnableWrites(ctx context.Context, project string, serviceName string) (string, error)
+	ServiceEnableWrites(ctx context.Context, project string, serviceName string) (*string, error)
 
 	// ServiceGet get service information
 	// GET /v1/project/{project}/service/{service_name}
@@ -342,16 +342,16 @@ func (h *ServiceHandler) ServiceDelete(ctx context.Context, project string, serv
 	_, err := h.doer.Do(ctx, "ServiceDelete", "DELETE", path, nil)
 	return err
 }
-func (h *ServiceHandler) ServiceEnableWrites(ctx context.Context, project string, serviceName string) (string, error) {
+func (h *ServiceHandler) ServiceEnableWrites(ctx context.Context, project string, serviceName string) (*string, error) {
 	path := fmt.Sprintf("/v1/project/%s/service/%s/enable-writes", url.PathEscape(project), url.PathEscape(serviceName))
 	b, err := h.doer.Do(ctx, "ServiceEnableWrites", "POST", path, nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	out := new(serviceEnableWritesOut)
 	err = json.Unmarshal(b, out)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	return out.Until, nil
 }
@@ -521,7 +521,7 @@ type AccessControlOut struct {
 	DragonflyAclCategories []string `json:"dragonfly_acl_categories,omitempty"`
 	DragonflyAclCommands   []string `json:"dragonfly_acl_commands,omitempty"`
 	DragonflyAclKeys       []string `json:"dragonfly_acl_keys,omitempty"`
-	M3Group                string   `json:"m3_group,omitempty"`
+	M3Group                *string  `json:"m3_group,omitempty"`
 	PgAllowReplication     *bool    `json:"pg_allow_replication,omitempty"`
 	RedisAclCategories     []string `json:"redis_acl_categories,omitempty"`
 	RedisAclChannels       []string `json:"redis_acl_channels,omitempty"`
@@ -529,31 +529,31 @@ type AccessControlOut struct {
 	RedisAclKeys           []string `json:"redis_acl_keys,omitempty"`
 }
 type AclOut struct {
-	Id         string         `json:"id,omitempty"`
+	Id         *string        `json:"id,omitempty"`
 	Permission PermissionType `json:"permission"`
 	Topic      string         `json:"topic"`
 	Username   string         `json:"username"`
 }
 type AdditionalRegionOut struct {
-	Cloud       string `json:"cloud"`
-	PauseReason string `json:"pause_reason,omitempty"`
-	Paused      *bool  `json:"paused,omitempty"`
-	Region      string `json:"region,omitempty"`
+	Cloud       string  `json:"cloud"`
+	PauseReason *string `json:"pause_reason,omitempty"`
+	Paused      *bool   `json:"paused,omitempty"`
+	Region      *string `json:"region,omitempty"`
 }
 type AggregatorOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
 type AlertOut struct {
 	CreateTime  time.Time `json:"create_time"`
 	Event       string    `json:"event"`
-	NodeName    string    `json:"node_name,omitempty"`
+	NodeName    *string   `json:"node_name,omitempty"`
 	ProjectName string    `json:"project_name"`
-	ServiceName string    `json:"service_name,omitempty"`
-	ServiceType string    `json:"service_type,omitempty"`
+	ServiceName *string   `json:"service_name,omitempty"`
+	ServiceType *string   `json:"service_type,omitempty"`
 	Severity    string    `json:"severity"`
 }
 type AuthenticationType string
@@ -582,19 +582,19 @@ type BackupOut struct {
 	BackupName        string                `json:"backup_name"`
 	BackupTime        time.Time             `json:"backup_time"`
 	DataSize          int                   `json:"data_size"`
-	StorageLocation   string                `json:"storage_location,omitempty"`
+	StorageLocation   *string               `json:"storage_location,omitempty"`
 }
 type CassandraOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
 type ClickhouseOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
@@ -603,9 +603,9 @@ type ComponentOut struct {
 	Host                      string                        `json:"host"`
 	KafkaAuthenticationMethod KafkaAuthenticationMethodType `json:"kafka_authentication_method,omitempty"`
 	KafkaSslCa                KafkaSslCaType                `json:"kafka_ssl_ca,omitempty"`
-	Path                      string                        `json:"path,omitempty"`
+	Path                      *string                       `json:"path,omitempty"`
 	Port                      int                           `json:"port"`
-	PrivatelinkConnectionId   string                        `json:"privatelink_connection_id,omitempty"`
+	PrivatelinkConnectionId   *string                       `json:"privatelink_connection_id,omitempty"`
 	Route                     RouteType                     `json:"route"`
 	Ssl                       *bool                         `json:"ssl,omitempty"`
 	Usage                     UsageType                     `json:"usage"`
@@ -616,7 +616,7 @@ type ConnectionPoolOut struct {
 	PoolMode      PoolModeType `json:"pool_mode"`
 	PoolName      string       `json:"pool_name"`
 	PoolSize      int          `json:"pool_size"`
-	Username      string       `json:"username,omitempty"`
+	Username      *string      `json:"username,omitempty"`
 }
 type DatabaseOut struct {
 	DatabaseName string `json:"database_name"`
@@ -635,9 +635,9 @@ func DatasetNameTypeChoices() []string {
 }
 
 type DbOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
@@ -675,37 +675,37 @@ func DowTypeAltChoices() []string {
 }
 
 type DragonflyOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
 type ElasticsearchOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
 type FlinkOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
 type GrafanaOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
 type InfluxdbOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
@@ -790,23 +790,23 @@ func KafkaAuthenticationMethodTypeChoices() []string {
 }
 
 type KafkaConnectOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
 type KafkaMirrormakerOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
 type KafkaOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
@@ -883,13 +883,13 @@ type ListPublicServiceTypesOut struct {
 	Redis            *RedisOut            `json:"redis,omitempty"`
 }
 type LogOut struct {
-	Msg  string `json:"msg"`
-	Time string `json:"time,omitempty"`
-	Unit string `json:"unit,omitempty"`
+	Msg  string  `json:"msg"`
+	Time *string `json:"time,omitempty"`
+	Unit *string `json:"unit,omitempty"`
 }
 type MaintenanceIn struct {
 	Dow  DowType `json:"dow,omitempty"`
-	Time string  `json:"time,omitempty"`
+	Time *string `json:"time,omitempty"`
 }
 type MaintenanceOut struct {
 	Dow     DowTypeAlt  `json:"dow"`
@@ -908,11 +908,11 @@ func MasterLinkStatusTypeChoices() []string {
 }
 
 type MetadataOut struct {
-	EndOfLifeHelpArticleUrl string     `json:"end_of_life_help_article_url,omitempty"`
-	EndOfLifePolicyUrl      string     `json:"end_of_life_policy_url,omitempty"`
+	EndOfLifeHelpArticleUrl *string    `json:"end_of_life_help_article_url,omitempty"`
+	EndOfLifePolicyUrl      *string    `json:"end_of_life_policy_url,omitempty"`
 	ServiceEndOfLifeTime    *time.Time `json:"service_end_of_life_time,omitempty"`
-	UpgradeToServiceType    string     `json:"upgrade_to_service_type,omitempty"`
-	UpgradeToVersion        string     `json:"upgrade_to_version,omitempty"`
+	UpgradeToServiceType    *string    `json:"upgrade_to_service_type,omitempty"`
+	UpgradeToVersion        *string    `json:"upgrade_to_version,omitempty"`
 }
 type MethodType string
 
@@ -940,15 +940,15 @@ func MethodTypeAltChoices() []string {
 }
 
 type MigrationCheckIn struct {
-	IgnoreDbs         string        `json:"ignore_dbs,omitempty"`
+	IgnoreDbs         *string       `json:"ignore_dbs,omitempty"`
 	Method            MethodTypeAlt `json:"method,omitempty"`
-	SourceProjectName string        `json:"source_project_name,omitempty"`
-	SourceServiceName string        `json:"source_service_name,omitempty"`
-	SourceServiceUri  string        `json:"source_service_uri,omitempty"`
+	SourceProjectName *string       `json:"source_project_name,omitempty"`
+	SourceServiceName *string       `json:"source_service_name,omitempty"`
+	SourceServiceUri  *string       `json:"source_service_uri,omitempty"`
 }
 type MigrationDetailOut struct {
 	Dbname string                    `json:"dbname"`
-	Error  string                    `json:"error,omitempty"`
+	Error  *string                   `json:"error,omitempty"`
 	Method MethodType                `json:"method"`
 	Status MigrationDetailStatusType `json:"status"`
 }
@@ -966,7 +966,7 @@ func MigrationDetailStatusTypeChoices() []string {
 }
 
 type MigrationOut struct {
-	Error                  string               `json:"error,omitempty"`
+	Error                  *string              `json:"error,omitempty"`
 	MasterLastIoSecondsAgo *int                 `json:"master_last_io_seconds_ago,omitempty"`
 	MasterLinkStatus       MasterLinkStatusType `json:"master_link_status,omitempty"`
 	Method                 MethodType           `json:"method"`
@@ -986,9 +986,9 @@ func MigrationStatusTypeChoices() []string {
 }
 
 type MysqlOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
@@ -1015,9 +1015,9 @@ func NodeStateTypeChoices() []string {
 }
 
 type OpensearchOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
@@ -1060,9 +1060,9 @@ func PermissionTypeAltChoices() []string {
 }
 
 type PgOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
@@ -1101,7 +1101,7 @@ type ProgressUpdateOut struct {
 }
 type ProjectGetServiceLogsIn struct {
 	Limit     *int          `json:"limit,omitempty"`
-	Offset    string        `json:"offset,omitempty"`
+	Offset    *string       `json:"offset,omitempty"`
 	SortOrder SortOrderType `json:"sort_order,omitempty"`
 }
 type ProjectGetServiceLogsOut struct {
@@ -1117,44 +1117,44 @@ type ProjectServiceTagsUpdateIn struct {
 }
 type QueryOut struct {
 	ActiveChannelSubscriptions                *int     `json:"active_channel_subscriptions,omitempty"`
-	ActiveDatabase                            string   `json:"active_database,omitempty"`
+	ActiveDatabase                            *string  `json:"active_database,omitempty"`
 	ActivePatternMatchingChannelSubscriptions *int     `json:"active_pattern_matching_channel_subscriptions,omitempty"`
-	ApplicationName                           string   `json:"application_name,omitempty"`
-	BackendStart                              string   `json:"backend_start,omitempty"`
-	BackendType                               string   `json:"backend_type,omitempty"`
+	ApplicationName                           *string  `json:"application_name,omitempty"`
+	BackendStart                              *string  `json:"backend_start,omitempty"`
+	BackendType                               *string  `json:"backend_type,omitempty"`
 	BackendXid                                *int     `json:"backend_xid,omitempty"`
 	BackendXmin                               *int     `json:"backend_xmin,omitempty"`
-	ClientAddr                                string   `json:"client_addr,omitempty"`
-	ClientHostname                            string   `json:"client_hostname,omitempty"`
+	ClientAddr                                *string  `json:"client_addr,omitempty"`
+	ClientHostname                            *string  `json:"client_hostname,omitempty"`
 	ClientPort                                *int     `json:"client_port,omitempty"`
 	ConnectionAgeSeconds                      *float64 `json:"connection_age_seconds,omitempty"`
 	ConnectionIdleSeconds                     *float64 `json:"connection_idle_seconds,omitempty"`
 	Datid                                     *int     `json:"datid,omitempty"`
-	Datname                                   string   `json:"datname,omitempty"`
+	Datname                                   *string  `json:"datname,omitempty"`
 	Flags                                     []string `json:"flags,omitempty"`
-	FlagsRaw                                  string   `json:"flags_raw,omitempty"`
-	Id                                        string   `json:"id,omitempty"`
+	FlagsRaw                                  *string  `json:"flags_raw,omitempty"`
+	Id                                        *string  `json:"id,omitempty"`
 	LeaderPid                                 *int     `json:"leader_pid,omitempty"`
 	MultiExecCommands                         *int     `json:"multi_exec_commands,omitempty"`
-	Name                                      string   `json:"name,omitempty"`
+	Name                                      *string  `json:"name,omitempty"`
 	OutputBuffer                              *int     `json:"output_buffer,omitempty"`
 	OutputBufferMemory                        *int     `json:"output_buffer_memory,omitempty"`
 	OutputListLength                          *int     `json:"output_list_length,omitempty"`
 	Pid                                       *int     `json:"pid,omitempty"`
-	Query                                     string   `json:"query,omitempty"`
+	Query                                     *string  `json:"query,omitempty"`
 	QueryBuffer                               *int     `json:"query_buffer,omitempty"`
 	QueryBufferFree                           *int     `json:"query_buffer_free,omitempty"`
 	QueryDuration                             *float64 `json:"query_duration,omitempty"`
 	QueryId                                   *int     `json:"query_id,omitempty"`
-	QueryStart                                string   `json:"query_start,omitempty"`
-	State                                     string   `json:"state,omitempty"`
-	StateChange                               string   `json:"state_change,omitempty"`
-	Usename                                   string   `json:"usename,omitempty"`
+	QueryStart                                *string  `json:"query_start,omitempty"`
+	State                                     *string  `json:"state,omitempty"`
+	StateChange                               *string  `json:"state_change,omitempty"`
+	Usename                                   *string  `json:"usename,omitempty"`
 	Usesysid                                  *int     `json:"usesysid,omitempty"`
-	WaitEvent                                 string   `json:"wait_event,omitempty"`
-	WaitEventType                             string   `json:"wait_event_type,omitempty"`
+	WaitEvent                                 *string  `json:"wait_event,omitempty"`
+	WaitEventType                             *string  `json:"wait_event_type,omitempty"`
 	Waiting                                   *bool    `json:"waiting,omitempty"`
-	XactStart                                 string   `json:"xact_start,omitempty"`
+	XactStart                                 *string  `json:"xact_start,omitempty"`
 }
 type RecoveryModeType string
 
@@ -1168,15 +1168,15 @@ func RecoveryModeTypeChoices() []string {
 }
 
 type RedisOut struct {
-	DefaultVersion         string           `json:"default_version,omitempty"`
+	DefaultVersion         *string          `json:"default_version,omitempty"`
 	Description            string           `json:"description"`
-	LatestAvailableVersion string           `json:"latest_available_version,omitempty"`
+	LatestAvailableVersion *string          `json:"latest_available_version,omitempty"`
 	ServicePlans           []ServicePlanOut `json:"service_plans"`
 	UserConfigSchema       map[string]any   `json:"user_config_schema"`
 }
 type ResultCodeOut struct {
-	Code   string `json:"code"`
-	Dbname string `json:"dbname,omitempty"`
+	Code   string  `json:"code"`
+	Dbname *string `json:"dbname,omitempty"`
 }
 type RoleType string
 
@@ -1204,7 +1204,7 @@ func RouteTypeChoices() []string {
 }
 
 type SchemaRegistryAclOut struct {
-	Id         string            `json:"id,omitempty"`
+	Id         *string           `json:"id,omitempty"`
 	Permission PermissionTypeAlt `json:"permission"`
 	Resource   string            `json:"resource"`
 	Username   string            `json:"username"`
@@ -1217,13 +1217,13 @@ type ServiceCancelQueryIn struct {
 	Terminate *bool `json:"terminate,omitempty"`
 }
 type ServiceCreateIn struct {
-	Cloud                 string                  `json:"cloud,omitempty"`
+	Cloud                 *string                 `json:"cloud,omitempty"`
 	CopyTags              *bool                   `json:"copy_tags,omitempty"`
 	DiskSpaceMb           *float64                `json:"disk_space_mb,omitempty"`
-	GroupName             string                  `json:"group_name,omitempty"`
+	GroupName             *string                 `json:"group_name,omitempty"`
 	Maintenance           *MaintenanceIn          `json:"maintenance,omitempty"`
 	Plan                  string                  `json:"plan"`
-	ProjectVpcId          string                  `json:"project_vpc_id,omitempty"`
+	ProjectVpcId          *string                 `json:"project_vpc_id,omitempty"`
 	ServiceIntegrations   *[]ServiceIntegrationIn `json:"service_integrations,omitempty"`
 	ServiceName           string                  `json:"service_name"`
 	ServiceType           string                  `json:"service_type"`
@@ -1236,7 +1236,7 @@ type ServiceCreateIn struct {
 type ServiceCreateOut struct {
 	Acl                    []AclOut                 `json:"acl,omitempty"`
 	Backups                []BackupOut              `json:"backups,omitempty"`
-	CloudDescription       string                   `json:"cloud_description,omitempty"`
+	CloudDescription       *string                  `json:"cloud_description,omitempty"`
 	CloudName              string                   `json:"cloud_name"`
 	Components             []ComponentOut           `json:"components,omitempty"`
 	ConnectionInfo         map[string]any           `json:"connection_info,omitempty"`
@@ -1259,7 +1259,7 @@ type ServiceCreateOut struct {
 	ServiceName            string                   `json:"service_name"`
 	ServiceNotifications   []ServiceNotificationOut `json:"service_notifications,omitempty"`
 	ServiceType            string                   `json:"service_type"`
-	ServiceTypeDescription string                   `json:"service_type_description,omitempty"`
+	ServiceTypeDescription *string                  `json:"service_type_description,omitempty"`
 	ServiceUri             string                   `json:"service_uri"`
 	ServiceUriParams       map[string]any           `json:"service_uri_params,omitempty"`
 	State                  ServiceStateType         `json:"state"`
@@ -1272,9 +1272,9 @@ type ServiceCreateOut struct {
 	Users                  []UserOut                `json:"users,omitempty"`
 }
 type ServiceDatabaseCreateIn struct {
-	Database  string `json:"database"`
-	LcCollate string `json:"lc_collate,omitempty"`
-	LcCtype   string `json:"lc_ctype,omitempty"`
+	Database  string  `json:"database"`
+	LcCollate *string `json:"lc_collate,omitempty"`
+	LcCtype   *string `json:"lc_ctype,omitempty"`
 }
 type ServiceGetMigrationStatusOut struct {
 	Migration       MigrationOut         `json:"migration"`
@@ -1283,7 +1283,7 @@ type ServiceGetMigrationStatusOut struct {
 type ServiceGetOut struct {
 	Acl                    []AclOut                 `json:"acl,omitempty"`
 	Backups                []BackupOut              `json:"backups,omitempty"`
-	CloudDescription       string                   `json:"cloud_description,omitempty"`
+	CloudDescription       *string                  `json:"cloud_description,omitempty"`
 	CloudName              string                   `json:"cloud_name"`
 	Components             []ComponentOut           `json:"components,omitempty"`
 	ConnectionInfo         map[string]any           `json:"connection_info,omitempty"`
@@ -1306,7 +1306,7 @@ type ServiceGetOut struct {
 	ServiceName            string                   `json:"service_name"`
 	ServiceNotifications   []ServiceNotificationOut `json:"service_notifications,omitempty"`
 	ServiceType            string                   `json:"service_type"`
-	ServiceTypeDescription string                   `json:"service_type_description,omitempty"`
+	ServiceTypeDescription *string                  `json:"service_type_description,omitempty"`
 	ServiceUri             string                   `json:"service_uri"`
 	ServiceUriParams       map[string]any           `json:"service_uri_params,omitempty"`
 	State                  ServiceStateType         `json:"state"`
@@ -1319,29 +1319,29 @@ type ServiceGetOut struct {
 	Users                  []UserOut                `json:"users,omitempty"`
 }
 type ServiceIntegrationIn struct {
-	DestEndpointId   string          `json:"dest_endpoint_id,omitempty"`
-	DestProject      string          `json:"dest_project,omitempty"`
-	DestService      string          `json:"dest_service,omitempty"`
+	DestEndpointId   *string         `json:"dest_endpoint_id,omitempty"`
+	DestProject      *string         `json:"dest_project,omitempty"`
+	DestService      *string         `json:"dest_service,omitempty"`
 	IntegrationType  IntegrationType `json:"integration_type"`
-	SourceEndpointId string          `json:"source_endpoint_id,omitempty"`
-	SourceProject    string          `json:"source_project,omitempty"`
-	SourceService    string          `json:"source_service,omitempty"`
+	SourceEndpointId *string         `json:"source_endpoint_id,omitempty"`
+	SourceProject    *string         `json:"source_project,omitempty"`
+	SourceService    *string         `json:"source_service,omitempty"`
 	UserConfig       *map[string]any `json:"user_config,omitempty"`
 }
 type ServiceIntegrationOut struct {
 	Active               bool                  `json:"active"`
 	Description          string                `json:"description"`
-	DestEndpoint         string                `json:"dest_endpoint,omitempty"`
-	DestEndpointId       string                `json:"dest_endpoint_id,omitempty"`
+	DestEndpoint         *string               `json:"dest_endpoint,omitempty"`
+	DestEndpointId       *string               `json:"dest_endpoint_id,omitempty"`
 	DestProject          string                `json:"dest_project"`
-	DestService          string                `json:"dest_service,omitempty"`
+	DestService          *string               `json:"dest_service,omitempty"`
 	DestServiceType      string                `json:"dest_service_type"`
 	Enabled              bool                  `json:"enabled"`
 	IntegrationStatus    *IntegrationStatusOut `json:"integration_status,omitempty"`
 	IntegrationType      string                `json:"integration_type"`
 	ServiceIntegrationId string                `json:"service_integration_id"`
-	SourceEndpoint       string                `json:"source_endpoint,omitempty"`
-	SourceEndpointId     string                `json:"source_endpoint_id,omitempty"`
+	SourceEndpoint       *string               `json:"source_endpoint,omitempty"`
+	SourceEndpointId     *string               `json:"source_endpoint_id,omitempty"`
 	SourceProject        string                `json:"source_project"`
 	SourceService        string                `json:"source_service"`
 	SourceServiceType    string                `json:"source_service_type"`
@@ -1374,7 +1374,7 @@ func ServiceNotificationTypeChoices() []string {
 type ServiceOut struct {
 	Acl                    []AclOut                 `json:"acl,omitempty"`
 	Backups                []BackupOut              `json:"backups,omitempty"`
-	CloudDescription       string                   `json:"cloud_description,omitempty"`
+	CloudDescription       *string                  `json:"cloud_description,omitempty"`
 	CloudName              string                   `json:"cloud_name"`
 	Components             []ComponentOut           `json:"components,omitempty"`
 	ConnectionInfo         map[string]any           `json:"connection_info,omitempty"`
@@ -1397,7 +1397,7 @@ type ServiceOut struct {
 	ServiceName            string                   `json:"service_name"`
 	ServiceNotifications   []ServiceNotificationOut `json:"service_notifications,omitempty"`
 	ServiceType            string                   `json:"service_type"`
-	ServiceTypeDescription string                   `json:"service_type_description,omitempty"`
+	ServiceTypeDescription *string                  `json:"service_type_description,omitempty"`
 	ServiceUri             string                   `json:"service_uri"`
 	ServiceUriParams       map[string]any           `json:"service_uri_params,omitempty"`
 	State                  ServiceStateType         `json:"state"`
@@ -1419,9 +1419,9 @@ type ServicePlanOut struct {
 	ShardCount       *int            `json:"shard_count,omitempty"`
 }
 type ServiceQueryActivityIn struct {
-	Limit   *int   `json:"limit,omitempty"`
-	Offset  *int   `json:"offset,omitempty"`
-	OrderBy string `json:"order_by,omitempty"`
+	Limit   *int    `json:"limit,omitempty"`
+	Offset  *int    `json:"offset,omitempty"`
+	OrderBy *string `json:"order_by,omitempty"`
 }
 type ServiceStateType string
 
@@ -1459,14 +1459,14 @@ type ServiceTaskGetOut struct {
 	TaskType    string          `json:"task_type"`
 }
 type ServiceUpdateIn struct {
-	Cloud                 string          `json:"cloud,omitempty"`
+	Cloud                 *string         `json:"cloud,omitempty"`
 	DiskSpaceMb           *float64        `json:"disk_space_mb,omitempty"`
-	GroupName             string          `json:"group_name,omitempty"`
+	GroupName             *string         `json:"group_name,omitempty"`
 	Karapace              *bool           `json:"karapace,omitempty"`
 	Maintenance           *MaintenanceIn  `json:"maintenance,omitempty"`
-	Plan                  string          `json:"plan,omitempty"`
+	Plan                  *string         `json:"plan,omitempty"`
 	Powered               *bool           `json:"powered,omitempty"`
-	ProjectVpcId          string          `json:"project_vpc_id,omitempty"`
+	ProjectVpcId          *string         `json:"project_vpc_id,omitempty"`
 	SchemaRegistryAuthz   *bool           `json:"schema_registry_authz,omitempty"`
 	TechEmails            *[]TechEmailIn  `json:"tech_emails,omitempty"`
 	TerminationProtection *bool           `json:"termination_protection,omitempty"`
@@ -1475,7 +1475,7 @@ type ServiceUpdateIn struct {
 type ServiceUpdateOut struct {
 	Acl                    []AclOut                 `json:"acl,omitempty"`
 	Backups                []BackupOut              `json:"backups,omitempty"`
-	CloudDescription       string                   `json:"cloud_description,omitempty"`
+	CloudDescription       *string                  `json:"cloud_description,omitempty"`
 	CloudName              string                   `json:"cloud_name"`
 	Components             []ComponentOut           `json:"components,omitempty"`
 	ConnectionInfo         map[string]any           `json:"connection_info,omitempty"`
@@ -1498,7 +1498,7 @@ type ServiceUpdateOut struct {
 	ServiceName            string                   `json:"service_name"`
 	ServiceNotifications   []ServiceNotificationOut `json:"service_notifications,omitempty"`
 	ServiceType            string                   `json:"service_type"`
-	ServiceTypeDescription string                   `json:"service_type_description,omitempty"`
+	ServiceTypeDescription *string                  `json:"service_type_description,omitempty"`
 	ServiceUri             string                   `json:"service_uri"`
 	ServiceUriParams       map[string]any           `json:"service_uri_params,omitempty"`
 	State                  ServiceStateType         `json:"state"`
@@ -1514,13 +1514,13 @@ type ServiceVersionOut struct {
 	AivenEndOfLifeTime      *time.Time              `json:"aiven_end_of_life_time,omitempty"`
 	AvailabilityEndTime     *time.Time              `json:"availability_end_time,omitempty"`
 	AvailabilityStartTime   *time.Time              `json:"availability_start_time,omitempty"`
-	EndOfLifeHelpArticleUrl string                  `json:"end_of_life_help_article_url,omitempty"`
-	MajorVersion            string                  `json:"major_version,omitempty"`
-	ServiceType             string                  `json:"service_type,omitempty"`
+	EndOfLifeHelpArticleUrl *string                 `json:"end_of_life_help_article_url,omitempty"`
+	MajorVersion            *string                 `json:"major_version,omitempty"`
+	ServiceType             *string                 `json:"service_type,omitempty"`
 	State                   ServiceVersionStateType `json:"state,omitempty"`
 	TerminationTime         *time.Time              `json:"termination_time,omitempty"`
-	UpgradeToServiceType    string                  `json:"upgrade_to_service_type,omitempty"`
-	UpgradeToVersion        string                  `json:"upgrade_to_version,omitempty"`
+	UpgradeToServiceType    *string                 `json:"upgrade_to_service_type,omitempty"`
+	UpgradeToVersion        *string                 `json:"upgrade_to_version,omitempty"`
 	UpstreamEndOfLifeTime   *time.Time              `json:"upstream_end_of_life_time,omitempty"`
 }
 type ServiceVersionStateType string
@@ -1538,8 +1538,8 @@ func ServiceVersionStateTypeChoices() []string {
 }
 
 type ShardOut struct {
-	Name     string `json:"name,omitempty"`
-	Position *int   `json:"position,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Position *int    `json:"position,omitempty"`
 }
 type SortOrderType string
 
@@ -1625,9 +1625,9 @@ func UnitTypeChoices() []string {
 }
 
 type UpdateOut struct {
-	Deadline    string     `json:"deadline,omitempty"`
-	Description string     `json:"description,omitempty"`
-	StartAfter  string     `json:"start_after,omitempty"`
+	Deadline    *string    `json:"deadline,omitempty"`
+	Description *string    `json:"description,omitempty"`
+	StartAfter  *string    `json:"start_after,omitempty"`
 	StartAt     *time.Time `json:"start_at,omitempty"`
 }
 type UsageType string
@@ -1642,10 +1642,10 @@ func UsageTypeChoices() []string {
 }
 
 type UserOut struct {
-	AccessCert                    string             `json:"access_cert,omitempty"`
+	AccessCert                    *string            `json:"access_cert,omitempty"`
 	AccessCertNotValidAfterTime   *time.Time         `json:"access_cert_not_valid_after_time,omitempty"`
 	AccessControl                 *AccessControlOut  `json:"access_control,omitempty"`
-	AccessKey                     string             `json:"access_key,omitempty"`
+	AccessKey                     *string            `json:"access_key,omitempty"`
 	Authentication                AuthenticationType `json:"authentication,omitempty"`
 	ExpiringCertNotValidAfterTime *time.Time         `json:"expiring_cert_not_valid_after_time,omitempty"`
 	Password                      string             `json:"password"`
@@ -1683,7 +1683,7 @@ type serviceDatabaseListOut struct {
 	Databases []DatabaseOut `json:"databases"`
 }
 type serviceEnableWritesOut struct {
-	Until string `json:"until,omitempty"`
+	Until *string `json:"until,omitempty"`
 }
 type serviceGetOut struct {
 	Service ServiceGetOut `json:"service"`

--- a/handler/serviceintegration/serviceintegration.go
+++ b/handler/serviceintegration/serviceintegration.go
@@ -351,29 +351,29 @@ func LikelyErrorCauseTypeChoices() []string {
 }
 
 type ServiceIntegrationCreateIn struct {
-	DestEndpointId   string          `json:"dest_endpoint_id,omitempty"`
-	DestProject      string          `json:"dest_project,omitempty"`
-	DestService      string          `json:"dest_service,omitempty"`
+	DestEndpointId   *string         `json:"dest_endpoint_id,omitempty"`
+	DestProject      *string         `json:"dest_project,omitempty"`
+	DestService      *string         `json:"dest_service,omitempty"`
 	IntegrationType  IntegrationType `json:"integration_type"`
-	SourceEndpointId string          `json:"source_endpoint_id,omitempty"`
-	SourceProject    string          `json:"source_project,omitempty"`
-	SourceService    string          `json:"source_service,omitempty"`
+	SourceEndpointId *string         `json:"source_endpoint_id,omitempty"`
+	SourceProject    *string         `json:"source_project,omitempty"`
+	SourceService    *string         `json:"source_service,omitempty"`
 	UserConfig       *map[string]any `json:"user_config,omitempty"`
 }
 type ServiceIntegrationCreateOut struct {
 	Active               bool                  `json:"active"`
 	Description          string                `json:"description"`
-	DestEndpoint         string                `json:"dest_endpoint,omitempty"`
-	DestEndpointId       string                `json:"dest_endpoint_id,omitempty"`
+	DestEndpoint         *string               `json:"dest_endpoint,omitempty"`
+	DestEndpointId       *string               `json:"dest_endpoint_id,omitempty"`
 	DestProject          string                `json:"dest_project"`
-	DestService          string                `json:"dest_service,omitempty"`
+	DestService          *string               `json:"dest_service,omitempty"`
 	DestServiceType      string                `json:"dest_service_type"`
 	Enabled              bool                  `json:"enabled"`
 	IntegrationStatus    *IntegrationStatusOut `json:"integration_status,omitempty"`
 	IntegrationType      string                `json:"integration_type"`
 	ServiceIntegrationId string                `json:"service_integration_id"`
-	SourceEndpoint       string                `json:"source_endpoint,omitempty"`
-	SourceEndpointId     string                `json:"source_endpoint_id,omitempty"`
+	SourceEndpoint       *string               `json:"source_endpoint,omitempty"`
+	SourceEndpointId     *string               `json:"source_endpoint_id,omitempty"`
 	SourceProject        string                `json:"source_project"`
 	SourceService        string                `json:"source_service"`
 	SourceServiceType    string                `json:"source_service_type"`
@@ -418,17 +418,17 @@ type ServiceIntegrationEndpointUpdateOut struct {
 type ServiceIntegrationGetOut struct {
 	Active               bool                  `json:"active"`
 	Description          string                `json:"description"`
-	DestEndpoint         string                `json:"dest_endpoint,omitempty"`
-	DestEndpointId       string                `json:"dest_endpoint_id,omitempty"`
+	DestEndpoint         *string               `json:"dest_endpoint,omitempty"`
+	DestEndpointId       *string               `json:"dest_endpoint_id,omitempty"`
 	DestProject          string                `json:"dest_project"`
-	DestService          string                `json:"dest_service,omitempty"`
+	DestService          *string               `json:"dest_service,omitempty"`
 	DestServiceType      string                `json:"dest_service_type"`
 	Enabled              bool                  `json:"enabled"`
 	IntegrationStatus    *IntegrationStatusOut `json:"integration_status,omitempty"`
 	IntegrationType      string                `json:"integration_type"`
 	ServiceIntegrationId string                `json:"service_integration_id"`
-	SourceEndpoint       string                `json:"source_endpoint,omitempty"`
-	SourceEndpointId     string                `json:"source_endpoint_id,omitempty"`
+	SourceEndpoint       *string               `json:"source_endpoint,omitempty"`
+	SourceEndpointId     *string               `json:"source_endpoint_id,omitempty"`
 	SourceProject        string                `json:"source_project"`
 	SourceService        string                `json:"source_service"`
 	SourceServiceType    string                `json:"source_service_type"`
@@ -437,17 +437,17 @@ type ServiceIntegrationGetOut struct {
 type ServiceIntegrationOut struct {
 	Active               bool                  `json:"active"`
 	Description          string                `json:"description"`
-	DestEndpoint         string                `json:"dest_endpoint,omitempty"`
-	DestEndpointId       string                `json:"dest_endpoint_id,omitempty"`
+	DestEndpoint         *string               `json:"dest_endpoint,omitempty"`
+	DestEndpointId       *string               `json:"dest_endpoint_id,omitempty"`
 	DestProject          string                `json:"dest_project"`
-	DestService          string                `json:"dest_service,omitempty"`
+	DestService          *string               `json:"dest_service,omitempty"`
 	DestServiceType      string                `json:"dest_service_type"`
 	Enabled              bool                  `json:"enabled"`
 	IntegrationStatus    *IntegrationStatusOut `json:"integration_status,omitempty"`
 	IntegrationType      string                `json:"integration_type"`
 	ServiceIntegrationId string                `json:"service_integration_id"`
-	SourceEndpoint       string                `json:"source_endpoint,omitempty"`
-	SourceEndpointId     string                `json:"source_endpoint_id,omitempty"`
+	SourceEndpoint       *string               `json:"source_endpoint,omitempty"`
+	SourceEndpointId     *string               `json:"source_endpoint_id,omitempty"`
 	SourceProject        string                `json:"source_project"`
 	SourceService        string                `json:"source_service"`
 	SourceServiceType    string                `json:"source_service_type"`
@@ -459,17 +459,17 @@ type ServiceIntegrationUpdateIn struct {
 type ServiceIntegrationUpdateOut struct {
 	Active               bool                  `json:"active"`
 	Description          string                `json:"description"`
-	DestEndpoint         string                `json:"dest_endpoint,omitempty"`
-	DestEndpointId       string                `json:"dest_endpoint_id,omitempty"`
+	DestEndpoint         *string               `json:"dest_endpoint,omitempty"`
+	DestEndpointId       *string               `json:"dest_endpoint_id,omitempty"`
 	DestProject          string                `json:"dest_project"`
-	DestService          string                `json:"dest_service,omitempty"`
+	DestService          *string               `json:"dest_service,omitempty"`
 	DestServiceType      string                `json:"dest_service_type"`
 	Enabled              bool                  `json:"enabled"`
 	IntegrationStatus    *IntegrationStatusOut `json:"integration_status,omitempty"`
 	IntegrationType      string                `json:"integration_type"`
 	ServiceIntegrationId string                `json:"service_integration_id"`
-	SourceEndpoint       string                `json:"source_endpoint,omitempty"`
-	SourceEndpointId     string                `json:"source_endpoint_id,omitempty"`
+	SourceEndpoint       *string               `json:"source_endpoint,omitempty"`
+	SourceEndpointId     *string               `json:"source_endpoint_id,omitempty"`
 	SourceProject        string                `json:"source_project"`
 	SourceService        string                `json:"source_service"`
 	SourceServiceType    string                `json:"source_service_type"`

--- a/handler/serviceuser/serviceuser.go
+++ b/handler/serviceuser/serviceuser.go
@@ -111,7 +111,7 @@ type AccessControlIn struct {
 	DragonflyAclCategories *[]string `json:"dragonfly_acl_categories,omitempty"`
 	DragonflyAclCommands   *[]string `json:"dragonfly_acl_commands,omitempty"`
 	DragonflyAclKeys       *[]string `json:"dragonfly_acl_keys,omitempty"`
-	M3Group                string    `json:"m3_group,omitempty"`
+	M3Group                *string   `json:"m3_group,omitempty"`
 	PgAllowReplication     *bool     `json:"pg_allow_replication,omitempty"`
 	RedisAclCategories     *[]string `json:"redis_acl_categories,omitempty"`
 	RedisAclChannels       *[]string `json:"redis_acl_channels,omitempty"`
@@ -122,7 +122,7 @@ type AccessControlOut struct {
 	DragonflyAclCategories []string `json:"dragonfly_acl_categories,omitempty"`
 	DragonflyAclCommands   []string `json:"dragonfly_acl_commands,omitempty"`
 	DragonflyAclKeys       []string `json:"dragonfly_acl_keys,omitempty"`
-	M3Group                string   `json:"m3_group,omitempty"`
+	M3Group                *string  `json:"m3_group,omitempty"`
 	PgAllowReplication     *bool    `json:"pg_allow_replication,omitempty"`
 	RedisAclCategories     []string `json:"redis_acl_categories,omitempty"`
 	RedisAclChannels       []string `json:"redis_acl_channels,omitempty"`
@@ -130,16 +130,16 @@ type AccessControlOut struct {
 	RedisAclKeys           []string `json:"redis_acl_keys,omitempty"`
 }
 type AclOut struct {
-	Id         string         `json:"id,omitempty"`
+	Id         *string        `json:"id,omitempty"`
 	Permission PermissionType `json:"permission"`
 	Topic      string         `json:"topic"`
 	Username   string         `json:"username"`
 }
 type AdditionalRegionOut struct {
-	Cloud       string `json:"cloud"`
-	PauseReason string `json:"pause_reason,omitempty"`
-	Paused      *bool  `json:"paused,omitempty"`
-	Region      string `json:"region,omitempty"`
+	Cloud       string  `json:"cloud"`
+	PauseReason *string `json:"pause_reason,omitempty"`
+	Paused      *bool   `json:"paused,omitempty"`
+	Region      *string `json:"region,omitempty"`
 }
 type AuthenticationType string
 
@@ -158,16 +158,16 @@ type BackupOut struct {
 	BackupName        string                `json:"backup_name"`
 	BackupTime        time.Time             `json:"backup_time"`
 	DataSize          int                   `json:"data_size"`
-	StorageLocation   string                `json:"storage_location,omitempty"`
+	StorageLocation   *string               `json:"storage_location,omitempty"`
 }
 type ComponentOut struct {
 	Component                 string                        `json:"component"`
 	Host                      string                        `json:"host"`
 	KafkaAuthenticationMethod KafkaAuthenticationMethodType `json:"kafka_authentication_method,omitempty"`
 	KafkaSslCa                KafkaSslCaType                `json:"kafka_ssl_ca,omitempty"`
-	Path                      string                        `json:"path,omitempty"`
+	Path                      *string                       `json:"path,omitempty"`
 	Port                      int                           `json:"port"`
-	PrivatelinkConnectionId   string                        `json:"privatelink_connection_id,omitempty"`
+	PrivatelinkConnectionId   *string                       `json:"privatelink_connection_id,omitempty"`
 	Route                     RouteType                     `json:"route"`
 	Ssl                       *bool                         `json:"ssl,omitempty"`
 	Usage                     UsageType                     `json:"usage"`
@@ -178,7 +178,7 @@ type ConnectionPoolOut struct {
 	PoolMode      PoolModeType `json:"pool_mode"`
 	PoolName      string       `json:"pool_name"`
 	PoolSize      int          `json:"pool_size"`
-	Username      string       `json:"username,omitempty"`
+	Username      *string      `json:"username,omitempty"`
 }
 type DowType string
 
@@ -268,11 +268,11 @@ type MaintenanceOut struct {
 	Updates []UpdateOut `json:"updates"`
 }
 type MetadataOut struct {
-	EndOfLifeHelpArticleUrl string     `json:"end_of_life_help_article_url,omitempty"`
-	EndOfLifePolicyUrl      string     `json:"end_of_life_policy_url,omitempty"`
+	EndOfLifeHelpArticleUrl *string    `json:"end_of_life_help_article_url,omitempty"`
+	EndOfLifePolicyUrl      *string    `json:"end_of_life_policy_url,omitempty"`
 	ServiceEndOfLifeTime    *time.Time `json:"service_end_of_life_time,omitempty"`
-	UpgradeToServiceType    string     `json:"upgrade_to_service_type,omitempty"`
-	UpgradeToVersion        string     `json:"upgrade_to_version,omitempty"`
+	UpgradeToServiceType    *string    `json:"upgrade_to_service_type,omitempty"`
+	UpgradeToVersion        *string    `json:"upgrade_to_version,omitempty"`
 }
 type NodeStateOut struct {
 	Name            string              `json:"name"`
@@ -391,7 +391,7 @@ func RouteTypeChoices() []string {
 }
 
 type SchemaRegistryAclOut struct {
-	Id         string            `json:"id,omitempty"`
+	Id         *string           `json:"id,omitempty"`
 	Permission PermissionTypeAlt `json:"permission"`
 	Resource   string            `json:"resource"`
 	Username   string            `json:"username"`
@@ -399,17 +399,17 @@ type SchemaRegistryAclOut struct {
 type ServiceIntegrationOut struct {
 	Active               bool                  `json:"active"`
 	Description          string                `json:"description"`
-	DestEndpoint         string                `json:"dest_endpoint,omitempty"`
-	DestEndpointId       string                `json:"dest_endpoint_id,omitempty"`
+	DestEndpoint         *string               `json:"dest_endpoint,omitempty"`
+	DestEndpointId       *string               `json:"dest_endpoint_id,omitempty"`
 	DestProject          string                `json:"dest_project"`
-	DestService          string                `json:"dest_service,omitempty"`
+	DestService          *string               `json:"dest_service,omitempty"`
 	DestServiceType      string                `json:"dest_service_type"`
 	Enabled              bool                  `json:"enabled"`
 	IntegrationStatus    *IntegrationStatusOut `json:"integration_status,omitempty"`
 	IntegrationType      string                `json:"integration_type"`
 	ServiceIntegrationId string                `json:"service_integration_id"`
-	SourceEndpoint       string                `json:"source_endpoint,omitempty"`
-	SourceEndpointId     string                `json:"source_endpoint_id,omitempty"`
+	SourceEndpoint       *string               `json:"source_endpoint,omitempty"`
+	SourceEndpointId     *string               `json:"source_endpoint_id,omitempty"`
 	SourceProject        string                `json:"source_project"`
 	SourceService        string                `json:"source_service"`
 	SourceServiceType    string                `json:"source_service_type"`
@@ -451,10 +451,10 @@ type ServiceUserCreateIn struct {
 	Username       string             `json:"username"`
 }
 type ServiceUserCreateOut struct {
-	AccessCert                    string             `json:"access_cert,omitempty"`
+	AccessCert                    *string            `json:"access_cert,omitempty"`
 	AccessCertNotValidAfterTime   *time.Time         `json:"access_cert_not_valid_after_time,omitempty"`
 	AccessControl                 *AccessControlOut  `json:"access_control,omitempty"`
-	AccessKey                     string             `json:"access_key,omitempty"`
+	AccessKey                     *string            `json:"access_key,omitempty"`
 	Authentication                AuthenticationType `json:"authentication,omitempty"`
 	ExpiringCertNotValidAfterTime *time.Time         `json:"expiring_cert_not_valid_after_time,omitempty"`
 	Password                      string             `json:"password"`
@@ -464,13 +464,13 @@ type ServiceUserCreateOut struct {
 type ServiceUserCredentialsModifyIn struct {
 	AccessControl  *AccessControlIn   `json:"access_control,omitempty"`
 	Authentication AuthenticationType `json:"authentication,omitempty"`
-	NewPassword    string             `json:"new_password,omitempty"`
+	NewPassword    *string            `json:"new_password,omitempty"`
 	Operation      OperationType      `json:"operation"`
 }
 type ServiceUserCredentialsModifyOut struct {
 	Acl                    []AclOut                 `json:"acl,omitempty"`
 	Backups                []BackupOut              `json:"backups,omitempty"`
-	CloudDescription       string                   `json:"cloud_description,omitempty"`
+	CloudDescription       *string                  `json:"cloud_description,omitempty"`
 	CloudName              string                   `json:"cloud_name"`
 	Components             []ComponentOut           `json:"components,omitempty"`
 	ConnectionInfo         map[string]any           `json:"connection_info,omitempty"`
@@ -493,7 +493,7 @@ type ServiceUserCredentialsModifyOut struct {
 	ServiceName            string                   `json:"service_name"`
 	ServiceNotifications   []ServiceNotificationOut `json:"service_notifications,omitempty"`
 	ServiceType            string                   `json:"service_type"`
-	ServiceTypeDescription string                   `json:"service_type_description,omitempty"`
+	ServiceTypeDescription *string                  `json:"service_type_description,omitempty"`
 	ServiceUri             string                   `json:"service_uri"`
 	ServiceUriParams       map[string]any           `json:"service_uri_params,omitempty"`
 	State                  ServiceStateType         `json:"state"`
@@ -508,7 +508,7 @@ type ServiceUserCredentialsModifyOut struct {
 type ServiceUserCredentialsResetOut struct {
 	Acl                    []AclOut                 `json:"acl,omitempty"`
 	Backups                []BackupOut              `json:"backups,omitempty"`
-	CloudDescription       string                   `json:"cloud_description,omitempty"`
+	CloudDescription       *string                  `json:"cloud_description,omitempty"`
 	CloudName              string                   `json:"cloud_name"`
 	Components             []ComponentOut           `json:"components,omitempty"`
 	ConnectionInfo         map[string]any           `json:"connection_info,omitempty"`
@@ -531,7 +531,7 @@ type ServiceUserCredentialsResetOut struct {
 	ServiceName            string                   `json:"service_name"`
 	ServiceNotifications   []ServiceNotificationOut `json:"service_notifications,omitempty"`
 	ServiceType            string                   `json:"service_type"`
-	ServiceTypeDescription string                   `json:"service_type_description,omitempty"`
+	ServiceTypeDescription *string                  `json:"service_type_description,omitempty"`
 	ServiceUri             string                   `json:"service_uri"`
 	ServiceUriParams       map[string]any           `json:"service_uri_params,omitempty"`
 	State                  ServiceStateType         `json:"state"`
@@ -544,10 +544,10 @@ type ServiceUserCredentialsResetOut struct {
 	Users                  []UserOut                `json:"users,omitempty"`
 }
 type ServiceUserGetOut struct {
-	AccessCert                    string             `json:"access_cert,omitempty"`
+	AccessCert                    *string            `json:"access_cert,omitempty"`
 	AccessCertNotValidAfterTime   *time.Time         `json:"access_cert_not_valid_after_time,omitempty"`
 	AccessControl                 *AccessControlOut  `json:"access_control,omitempty"`
-	AccessKey                     string             `json:"access_key,omitempty"`
+	AccessKey                     *string            `json:"access_key,omitempty"`
 	Authentication                AuthenticationType `json:"authentication,omitempty"`
 	ExpiringCertNotValidAfterTime *time.Time         `json:"expiring_cert_not_valid_after_time,omitempty"`
 	Password                      string             `json:"password"`
@@ -555,8 +555,8 @@ type ServiceUserGetOut struct {
 	Username                      string             `json:"username"`
 }
 type ShardOut struct {
-	Name     string `json:"name,omitempty"`
-	Position *int   `json:"position,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Position *int    `json:"position,omitempty"`
 }
 type StateOut struct {
 	Errors           []string              `json:"errors"`
@@ -603,9 +603,9 @@ func UnitTypeChoices() []string {
 }
 
 type UpdateOut struct {
-	Deadline    string     `json:"deadline,omitempty"`
-	Description string     `json:"description,omitempty"`
-	StartAfter  string     `json:"start_after,omitempty"`
+	Deadline    *string    `json:"deadline,omitempty"`
+	Description *string    `json:"description,omitempty"`
+	StartAfter  *string    `json:"start_after,omitempty"`
 	StartAt     *time.Time `json:"start_at,omitempty"`
 }
 type UsageType string
@@ -620,10 +620,10 @@ func UsageTypeChoices() []string {
 }
 
 type UserOut struct {
-	AccessCert                    string             `json:"access_cert,omitempty"`
+	AccessCert                    *string            `json:"access_cert,omitempty"`
 	AccessCertNotValidAfterTime   *time.Time         `json:"access_cert_not_valid_after_time,omitempty"`
 	AccessControl                 *AccessControlOut  `json:"access_control,omitempty"`
-	AccessKey                     string             `json:"access_key,omitempty"`
+	AccessKey                     *string            `json:"access_key,omitempty"`
 	Authentication                AuthenticationType `json:"authentication,omitempty"`
 	ExpiringCertNotValidAfterTime *time.Time         `json:"expiring_cert_not_valid_after_time,omitempty"`
 	Password                      string             `json:"password"`

--- a/handler/thanos/thanos.go
+++ b/handler/thanos/thanos.go
@@ -43,14 +43,14 @@ func (h *ThanosHandler) ServiceThanosStorageSummary(ctx context.Context, project
 }
 
 type HourlyOut struct {
-	EstimatedCost   string `json:"estimated_cost,omitempty"`
-	HourStart       string `json:"hour_start"`
-	PeakStoredBytes int    `json:"peak_stored_bytes"`
+	EstimatedCost   *string `json:"estimated_cost,omitempty"`
+	HourStart       string  `json:"hour_start"`
+	PeakStoredBytes int     `json:"peak_stored_bytes"`
 }
 type ServiceThanosStorageSummaryOut struct {
 	CurrentCost         string                 `json:"current_cost"`
 	ForecastedCost      string                 `json:"forecasted_cost"`
-	ForecastedRate      string                 `json:"forecasted_rate,omitempty"`
+	ForecastedRate      *string                `json:"forecasted_rate,omitempty"`
 	StorageUsageHistory StorageUsageHistoryOut `json:"storage_usage_history"`
 	TotalStorageUsage   int                    `json:"total_storage_usage"`
 }

--- a/handler/user/user.go
+++ b/handler/user/user.go
@@ -431,14 +431,14 @@ type AccessTokenCreateOut struct {
 	CreateTime                 time.Time  `json:"create_time"`
 	CreatedManually            bool       `json:"created_manually"`
 	CurrentlyActive            *bool      `json:"currently_active,omitempty"`
-	Description                string     `json:"description,omitempty"`
+	Description                *string    `json:"description,omitempty"`
 	ExpiryTime                 *time.Time `json:"expiry_time,omitempty"`
 	ExtendWhenUsed             bool       `json:"extend_when_used"`
 	FullToken                  string     `json:"full_token"`
-	LastIp                     string     `json:"last_ip,omitempty"`
+	LastIp                     *string    `json:"last_ip,omitempty"`
 	LastUsedTime               *time.Time `json:"last_used_time,omitempty"`
-	LastUserAgent              string     `json:"last_user_agent,omitempty"`
-	LastUserAgentHumanReadable string     `json:"last_user_agent_human_readable,omitempty"`
+	LastUserAgent              *string    `json:"last_user_agent,omitempty"`
+	LastUserAgentHumanReadable *string    `json:"last_user_agent_human_readable,omitempty"`
 	MaxAgeSeconds              float64    `json:"max_age_seconds"`
 	Scopes                     []string   `json:"scopes,omitempty"`
 	TokenPrefix                string     `json:"token_prefix"`
@@ -450,13 +450,13 @@ type AccessTokenUpdateOut struct {
 	CreateTime                 time.Time  `json:"create_time"`
 	CreatedManually            *bool      `json:"created_manually,omitempty"`
 	CurrentlyActive            *bool      `json:"currently_active,omitempty"`
-	Description                string     `json:"description,omitempty"`
+	Description                *string    `json:"description,omitempty"`
 	ExpiryTime                 *time.Time `json:"expiry_time,omitempty"`
 	ExtendWhenUsed             bool       `json:"extend_when_used"`
-	LastIp                     string     `json:"last_ip,omitempty"`
+	LastIp                     *string    `json:"last_ip,omitempty"`
 	LastUsedTime               *time.Time `json:"last_used_time,omitempty"`
-	LastUserAgent              string     `json:"last_user_agent,omitempty"`
-	LastUserAgentHumanReadable string     `json:"last_user_agent_human_readable,omitempty"`
+	LastUserAgent              *string    `json:"last_user_agent,omitempty"`
+	LastUserAgentHumanReadable *string    `json:"last_user_agent_human_readable,omitempty"`
 	MaxAgeSeconds              float64    `json:"max_age_seconds"`
 	Scopes                     []string   `json:"scopes,omitempty"`
 	TokenPrefix                string     `json:"token_prefix"`
@@ -506,7 +506,7 @@ type AuthenticationMethodOut struct {
 	DeleteTime                    time.Time                     `json:"delete_time"`
 	LastUsedTime                  time.Time                     `json:"last_used_time"`
 	MethodId                      string                        `json:"method_id"`
-	Name                          string                        `json:"name,omitempty"`
+	Name                          *string                       `json:"name,omitempty"`
 	PublicRemoteIdentity          string                        `json:"public_remote_identity"`
 	RemoteProviderId              string                        `json:"remote_provider_id"`
 	State                         AuthenticationMethodStateType `json:"state"`
@@ -534,9 +534,9 @@ type CheckPasswordStrengthExistingUserOut struct {
 	Score        int    `json:"score"`
 }
 type CheckPasswordStrengthNewUserIn struct {
-	Email    string `json:"email,omitempty"`
-	Password string `json:"password"`
-	RealName string `json:"real_name,omitempty"`
+	Email    *string `json:"email,omitempty"`
+	Password string  `json:"password"`
+	RealName *string `json:"real_name,omitempty"`
 }
 type CheckPasswordStrengthNewUserOut struct {
 	IsAcceptable *bool  `json:"is_acceptable,omitempty"`
@@ -574,13 +574,13 @@ type TokenOut struct {
 	CreateTime                 time.Time  `json:"create_time"`
 	CreatedManually            bool       `json:"created_manually"`
 	CurrentlyActive            *bool      `json:"currently_active,omitempty"`
-	Description                string     `json:"description,omitempty"`
+	Description                *string    `json:"description,omitempty"`
 	ExpiryTime                 *time.Time `json:"expiry_time,omitempty"`
 	ExtendWhenUsed             bool       `json:"extend_when_used"`
-	LastIp                     string     `json:"last_ip,omitempty"`
+	LastIp                     *string    `json:"last_ip,omitempty"`
 	LastUsedTime               *time.Time `json:"last_used_time,omitempty"`
-	LastUserAgent              string     `json:"last_user_agent,omitempty"`
-	LastUserAgentHumanReadable string     `json:"last_user_agent_human_readable,omitempty"`
+	LastUserAgent              *string    `json:"last_user_agent,omitempty"`
+	LastUserAgentHumanReadable *string    `json:"last_user_agent_human_readable,omitempty"`
 	MaxAgeSeconds              float64    `json:"max_age_seconds"`
 	Scopes                     []string   `json:"scopes,omitempty"`
 	TokenPrefix                string     `json:"token_prefix"`
@@ -599,34 +599,34 @@ type TwoFactorAuthConfigureOtpOut struct {
 	Token  string `json:"token"`
 }
 type TwoFactorAuthConfigureOut struct {
-	Method string `json:"method"`
-	Qrcode string `json:"qrcode,omitempty"`
-	Uri    string `json:"uri,omitempty"`
+	Method string  `json:"method"`
+	Qrcode *string `json:"qrcode,omitempty"`
+	Uri    *string `json:"uri,omitempty"`
 }
 type UserAccountInvitesAcceptIn struct {
-	AccountId string `json:"account_id"`
-	TeamId    string `json:"team_id,omitempty"`
+	AccountId string  `json:"account_id"`
+	TeamId    *string `json:"team_id,omitempty"`
 }
 type UserAuthIn struct {
-	Email    string `json:"email"`
-	Otp      string `json:"otp,omitempty"`
-	Password string `json:"password"`
+	Email    string  `json:"email"`
+	Otp      *string `json:"otp,omitempty"`
+	Password string  `json:"password"`
 }
 type UserAuthLoginOptionsIn struct {
-	Email string `json:"email,omitempty"`
+	Email *string `json:"email,omitempty"`
 }
 type UserAuthLoginOptionsOut struct {
 	None        []map[string]any `json:"None,omitempty"`
 	Action      ActionType       `json:"action"`
 	Method      MethodType       `json:"method,omitempty"`
-	Name        string           `json:"name,omitempty"`
-	RedirectUrl string           `json:"redirect_url,omitempty"`
+	Name        *string          `json:"name,omitempty"`
+	RedirectUrl *string          `json:"redirect_url,omitempty"`
 }
 type UserAuthOut struct {
-	ReturnUrl string `json:"return_url,omitempty"`
-	State     string `json:"state"`
-	Token     string `json:"token"`
-	UserEmail string `json:"user_email"`
+	ReturnUrl *string `json:"return_url,omitempty"`
+	State     string  `json:"state"`
+	Token     string  `json:"token"`
+	UserEmail string  `json:"user_email"`
 }
 type UserGroupOut struct {
 	CreateTime    time.Time `json:"create_time"`
@@ -638,22 +638,22 @@ type UserGroupOut struct {
 }
 type UserInfoOut struct {
 	Auth                   []string               `json:"auth"`
-	City                   string                 `json:"city,omitempty"`
-	Country                string                 `json:"country,omitempty"`
+	City                   *string                `json:"city,omitempty"`
+	Country                *string                `json:"country,omitempty"`
 	CreateTime             *time.Time             `json:"create_time,omitempty"`
-	Department             string                 `json:"department,omitempty"`
+	Department             *string                `json:"department,omitempty"`
 	Features               map[string]any         `json:"features,omitempty"`
 	Intercom               IntercomOut            `json:"intercom"`
 	Invitations            []InvitationOut        `json:"invitations"`
-	JobTitle               string                 `json:"job_title,omitempty"`
+	JobTitle               *string                `json:"job_title,omitempty"`
 	ManagedByScim          *bool                  `json:"managed_by_scim,omitempty"`
-	ManagingOrganizationId string                 `json:"managing_organization_id,omitempty"`
+	ManagingOrganizationId *string                `json:"managing_organization_id,omitempty"`
 	ProjectMembership      ProjectMembershipOut   `json:"project_membership"`
 	ProjectMemberships     *ProjectMembershipsOut `json:"project_memberships,omitempty"`
 	Projects               []string               `json:"projects"`
 	RealName               string                 `json:"real_name"`
 	State                  string                 `json:"state"`
-	TokenValidityBegin     string                 `json:"token_validity_begin,omitempty"`
+	TokenValidityBegin     *string                `json:"token_validity_begin,omitempty"`
 	User                   string                 `json:"user"`
 	UserId                 string                 `json:"user_id"`
 }
@@ -668,30 +668,30 @@ type UserPasswordResetRequestIn struct {
 	Email string `json:"email"`
 }
 type UserUpdateIn struct {
-	City       string `json:"city,omitempty"`
-	Country    string `json:"country,omitempty"`
-	Department string `json:"department,omitempty"`
-	JobTitle   string `json:"job_title,omitempty"`
-	RealName   string `json:"real_name"`
+	City       *string `json:"city,omitempty"`
+	Country    *string `json:"country,omitempty"`
+	Department *string `json:"department,omitempty"`
+	JobTitle   *string `json:"job_title,omitempty"`
+	RealName   string  `json:"real_name"`
 }
 type UserUpdateOut struct {
 	Auth                   []string               `json:"auth"`
-	City                   string                 `json:"city,omitempty"`
-	Country                string                 `json:"country,omitempty"`
+	City                   *string                `json:"city,omitempty"`
+	Country                *string                `json:"country,omitempty"`
 	CreateTime             *time.Time             `json:"create_time,omitempty"`
-	Department             string                 `json:"department,omitempty"`
+	Department             *string                `json:"department,omitempty"`
 	Features               map[string]any         `json:"features,omitempty"`
 	Intercom               IntercomOut            `json:"intercom"`
 	Invitations            []InvitationOut        `json:"invitations"`
-	JobTitle               string                 `json:"job_title,omitempty"`
+	JobTitle               *string                `json:"job_title,omitempty"`
 	ManagedByScim          *bool                  `json:"managed_by_scim,omitempty"`
-	ManagingOrganizationId string                 `json:"managing_organization_id,omitempty"`
+	ManagingOrganizationId *string                `json:"managing_organization_id,omitempty"`
 	ProjectMembership      ProjectMembershipOut   `json:"project_membership"`
 	ProjectMemberships     *ProjectMembershipsOut `json:"project_memberships,omitempty"`
 	Projects               []string               `json:"projects"`
 	RealName               string                 `json:"real_name"`
 	State                  string                 `json:"state"`
-	TokenValidityBegin     string                 `json:"token_validity_begin,omitempty"`
+	TokenValidityBegin     *string                `json:"token_validity_begin,omitempty"`
 	User                   string                 `json:"user"`
 	UserId                 string                 `json:"user_id"`
 }

--- a/handler/usergroup/usergroup.go
+++ b/handler/usergroup/usergroup.go
@@ -185,8 +185,8 @@ type UserGroupOut struct {
 	UserGroupName string    `json:"user_group_name"`
 }
 type UserGroupUpdateIn struct {
-	Description   string `json:"description,omitempty"`
-	UserGroupName string `json:"user_group_name,omitempty"`
+	Description   *string `json:"description,omitempty"`
+	UserGroupName *string `json:"user_group_name,omitempty"`
 }
 type UserGroupUpdateOut struct {
 	CreateTime    time.Time `json:"create_time"`
@@ -197,14 +197,14 @@ type UserGroupUpdateOut struct {
 	UserGroupName string    `json:"user_group_name"`
 }
 type UserInfoOut struct {
-	City                   string    `json:"city,omitempty"`
-	Country                string    `json:"country,omitempty"`
+	City                   *string   `json:"city,omitempty"`
+	Country                *string   `json:"country,omitempty"`
 	CreateTime             time.Time `json:"create_time"`
-	Department             string    `json:"department,omitempty"`
+	Department             *string   `json:"department,omitempty"`
 	IsApplicationUser      bool      `json:"is_application_user"`
-	JobTitle               string    `json:"job_title,omitempty"`
+	JobTitle               *string   `json:"job_title,omitempty"`
 	ManagedByScim          bool      `json:"managed_by_scim"`
-	ManagingOrganizationId string    `json:"managing_organization_id,omitempty"`
+	ManagingOrganizationId *string   `json:"managing_organization_id,omitempty"`
 	RealName               string    `json:"real_name"`
 	State                  string    `json:"state"`
 	UserEmail              string    `json:"user_email"`

--- a/handler/vpc/vpc.go
+++ b/handler/vpc/vpc.go
@@ -188,17 +188,17 @@ func (h *VpcHandler) VpcPeeringConnectionWithResourceGroupDelete(ctx context.Con
 }
 
 type AddIn struct {
-	Cidr              string `json:"cidr"`
-	PeerCloudAccount  string `json:"peer_cloud_account"`
-	PeerResourceGroup string `json:"peer_resource_group,omitempty"`
-	PeerVpc           string `json:"peer_vpc"`
+	Cidr              string  `json:"cidr"`
+	PeerCloudAccount  string  `json:"peer_cloud_account"`
+	PeerResourceGroup *string `json:"peer_resource_group,omitempty"`
+	PeerVpc           string  `json:"peer_vpc"`
 }
 type PeeringConnectionIn struct {
-	PeerAzureAppId       string    `json:"peer_azure_app_id,omitempty"`
-	PeerAzureTenantId    string    `json:"peer_azure_tenant_id,omitempty"`
+	PeerAzureAppId       *string   `json:"peer_azure_app_id,omitempty"`
+	PeerAzureTenantId    *string   `json:"peer_azure_tenant_id,omitempty"`
 	PeerCloudAccount     string    `json:"peer_cloud_account"`
-	PeerRegion           string    `json:"peer_region,omitempty"`
-	PeerResourceGroup    string    `json:"peer_resource_group,omitempty"`
+	PeerRegion           *string   `json:"peer_region,omitempty"`
+	PeerResourceGroup    *string   `json:"peer_resource_group,omitempty"`
 	PeerVpc              string    `json:"peer_vpc"`
 	UserPeerNetworkCidrs *[]string `json:"user_peer_network_cidrs,omitempty"`
 }
@@ -207,7 +207,7 @@ type PeeringConnectionOut struct {
 	PeerAzureAppId           string                        `json:"peer_azure_app_id"`
 	PeerAzureTenantId        string                        `json:"peer_azure_tenant_id"`
 	PeerCloudAccount         string                        `json:"peer_cloud_account"`
-	PeerRegion               string                        `json:"peer_region,omitempty"`
+	PeerRegion               *string                       `json:"peer_region,omitempty"`
 	PeerResourceGroup        string                        `json:"peer_resource_group"`
 	PeerVpc                  string                        `json:"peer_vpc"`
 	State                    VpcPeeringConnectionStateType `json:"state"`
@@ -231,7 +231,7 @@ type VpcCreateOut struct {
 	CreateTime                         time.Time              `json:"create_time"`
 	NetworkCidr                        string                 `json:"network_cidr"`
 	PeeringConnections                 []PeeringConnectionOut `json:"peering_connections"`
-	PendingBuildOnlyPeeringConnections string                 `json:"pending_build_only_peering_connections,omitempty"`
+	PendingBuildOnlyPeeringConnections *string                `json:"pending_build_only_peering_connections,omitempty"`
 	ProjectVpcId                       string                 `json:"project_vpc_id"`
 	State                              VpcStateType           `json:"state"`
 	UpdateTime                         time.Time              `json:"update_time"`
@@ -241,7 +241,7 @@ type VpcDeleteOut struct {
 	CreateTime                         time.Time              `json:"create_time"`
 	NetworkCidr                        string                 `json:"network_cidr"`
 	PeeringConnections                 []PeeringConnectionOut `json:"peering_connections"`
-	PendingBuildOnlyPeeringConnections string                 `json:"pending_build_only_peering_connections,omitempty"`
+	PendingBuildOnlyPeeringConnections *string                `json:"pending_build_only_peering_connections,omitempty"`
 	ProjectVpcId                       string                 `json:"project_vpc_id"`
 	State                              VpcStateType           `json:"state"`
 	UpdateTime                         time.Time              `json:"update_time"`
@@ -251,7 +251,7 @@ type VpcGetOut struct {
 	CreateTime                         time.Time              `json:"create_time"`
 	NetworkCidr                        string                 `json:"network_cidr"`
 	PeeringConnections                 []PeeringConnectionOut `json:"peering_connections"`
-	PendingBuildOnlyPeeringConnections string                 `json:"pending_build_only_peering_connections,omitempty"`
+	PendingBuildOnlyPeeringConnections *string                `json:"pending_build_only_peering_connections,omitempty"`
 	ProjectVpcId                       string                 `json:"project_vpc_id"`
 	State                              VpcStateType           `json:"state"`
 	UpdateTime                         time.Time              `json:"update_time"`
@@ -265,11 +265,11 @@ type VpcOut struct {
 	UpdateTime   time.Time    `json:"update_time"`
 }
 type VpcPeeringConnectionCreateIn struct {
-	PeerAzureAppId       string    `json:"peer_azure_app_id,omitempty"`
-	PeerAzureTenantId    string    `json:"peer_azure_tenant_id,omitempty"`
+	PeerAzureAppId       *string   `json:"peer_azure_app_id,omitempty"`
+	PeerAzureTenantId    *string   `json:"peer_azure_tenant_id,omitempty"`
 	PeerCloudAccount     string    `json:"peer_cloud_account"`
-	PeerRegion           string    `json:"peer_region,omitempty"`
-	PeerResourceGroup    string    `json:"peer_resource_group,omitempty"`
+	PeerRegion           *string   `json:"peer_region,omitempty"`
+	PeerResourceGroup    *string   `json:"peer_resource_group,omitempty"`
 	PeerVpc              string    `json:"peer_vpc"`
 	UserPeerNetworkCidrs *[]string `json:"user_peer_network_cidrs,omitempty"`
 }
@@ -278,7 +278,7 @@ type VpcPeeringConnectionCreateOut struct {
 	PeerAzureAppId           string                        `json:"peer_azure_app_id"`
 	PeerAzureTenantId        string                        `json:"peer_azure_tenant_id"`
 	PeerCloudAccount         string                        `json:"peer_cloud_account"`
-	PeerRegion               string                        `json:"peer_region,omitempty"`
+	PeerRegion               *string                       `json:"peer_region,omitempty"`
 	PeerResourceGroup        string                        `json:"peer_resource_group"`
 	PeerVpc                  string                        `json:"peer_vpc"`
 	State                    VpcPeeringConnectionStateType `json:"state"`
@@ -292,7 +292,7 @@ type VpcPeeringConnectionDeleteOut struct {
 	PeerAzureAppId           string                        `json:"peer_azure_app_id"`
 	PeerAzureTenantId        string                        `json:"peer_azure_tenant_id"`
 	PeerCloudAccount         string                        `json:"peer_cloud_account"`
-	PeerRegion               string                        `json:"peer_region,omitempty"`
+	PeerRegion               *string                       `json:"peer_region,omitempty"`
 	PeerResourceGroup        string                        `json:"peer_resource_group"`
 	PeerVpc                  string                        `json:"peer_vpc"`
 	State                    VpcPeeringConnectionStateType `json:"state"`
@@ -356,7 +356,7 @@ type VpcPeeringConnectionUpdateOut struct {
 	CreateTime                         time.Time                        `json:"create_time"`
 	NetworkCidr                        string                           `json:"network_cidr"`
 	PeeringConnections                 []PeeringConnectionOut           `json:"peering_connections"`
-	PendingBuildOnlyPeeringConnections string                           `json:"pending_build_only_peering_connections,omitempty"`
+	PendingBuildOnlyPeeringConnections *string                          `json:"pending_build_only_peering_connections,omitempty"`
 	ProjectVpcId                       string                           `json:"project_vpc_id"`
 	State                              VpcPeeringConnectionStateTypeAlt `json:"state"`
 	UpdateTime                         time.Time                        `json:"update_time"`
@@ -366,7 +366,7 @@ type VpcPeeringConnectionWithRegionDeleteOut struct {
 	PeerAzureAppId           string                        `json:"peer_azure_app_id"`
 	PeerAzureTenantId        string                        `json:"peer_azure_tenant_id"`
 	PeerCloudAccount         string                        `json:"peer_cloud_account"`
-	PeerRegion               string                        `json:"peer_region,omitempty"`
+	PeerRegion               *string                       `json:"peer_region,omitempty"`
 	PeerResourceGroup        string                        `json:"peer_resource_group"`
 	PeerVpc                  string                        `json:"peer_vpc"`
 	State                    VpcPeeringConnectionStateType `json:"state"`
@@ -380,7 +380,7 @@ type VpcPeeringConnectionWithResourceGroupDeleteOut struct {
 	PeerAzureAppId           string                        `json:"peer_azure_app_id"`
 	PeerAzureTenantId        string                        `json:"peer_azure_tenant_id"`
 	PeerCloudAccount         string                        `json:"peer_cloud_account"`
-	PeerRegion               string                        `json:"peer_region,omitempty"`
+	PeerRegion               *string                       `json:"peer_region,omitempty"`
 	PeerResourceGroup        string                        `json:"peer_resource_group"`
 	PeerVpc                  string                        `json:"peer_vpc"`
 	State                    VpcPeeringConnectionStateType `json:"state"`
@@ -403,9 +403,9 @@ func VpcStateTypeChoices() []string {
 }
 
 type WarningOut struct {
-	ConflictingAwsAccountId              string      `json:"conflicting_aws_account_id,omitempty"`
-	ConflictingAwsVpcId                  string      `json:"conflicting_aws_vpc_id,omitempty"`
-	ConflictingAwsVpcPeeringConnectionId string      `json:"conflicting_aws_vpc_peering_connection_id,omitempty"`
+	ConflictingAwsAccountId              *string     `json:"conflicting_aws_account_id,omitempty"`
+	ConflictingAwsVpcId                  *string     `json:"conflicting_aws_vpc_id,omitempty"`
+	ConflictingAwsVpcPeeringConnectionId *string     `json:"conflicting_aws_vpc_peering_connection_id,omitempty"`
 	Message                              string      `json:"message"`
 	Type                                 WarningType `json:"type"`
 }


### PR DESCRIPTION
KafkaMirrormakerReplicationFlow.config_properties_exclude field takes empty string to purge existing value.
While omitempty json tag make the JSON encoder ignore empty strings, we must use string pointers to handle this situation.

THIS IS A BREAKING CHANGE.
