### PR TITLE
docs: flatten multiline comments

### DIFF
--- a/generator/main.go
+++ b/generator/main.go
@@ -460,14 +460,14 @@ func writeStruct(f *jen.File, s *Schema) error {
 
 		// Adds a comment if it's not equal to the field name
 		if p.Description != "" && p.Description != p.CamelName {
-			field = field.Add(jen.Comment(p.Description))
+			field = field.Add(jen.Comment(fmtComment(p.Description)))
 		}
 
 		fields = append(fields, field)
 	}
 
 	if s.Description != "" {
-		f.Comment(fmt.Sprintf("%s %s", s.CamelName, s.Description))
+		f.Comment(fmt.Sprintf("%s %s", s.CamelName, fmtComment(s.Description)))
 	}
 
 	f.Type().Id(s.CamelName).Struct(fields...)
@@ -538,4 +538,12 @@ func readConfig(path string) (map[string][]string, error) {
 	}
 
 	return c, nil
+}
+
+// reComment finds new lines and trailing period,
+// which is added in fmtComment as a separater
+var reComment = regexp.MustCompile(`\.?[\r\n]+\s*?`)
+
+func fmtComment(c string) string {
+	return reComment.ReplaceAllString(c, ". ")
 }

--- a/handler/kafkamirrormaker/kafkamirrormaker.go
+++ b/handler/kafkamirrormaker/kafkamirrormaker.go
@@ -123,12 +123,8 @@ type ReplicationFlowOut struct {
 	SyncGroupOffsetsEnabled         *bool                        `json:"sync_group_offsets_enabled,omitempty"`          // Sync consumer group offsets
 	SyncGroupOffsetsIntervalSeconds *int                         `json:"sync_group_offsets_interval_seconds,omitempty"` // Frequency of consumer group offset sync
 	TargetCluster                   string                       `json:"target_cluster"`                                // Target cluster alias
-	Topics                          []string                     `json:"topics,omitempty"`                              /*
-		List of topics and/or regular expressions to replicate.
-
-		Topic names and regular expressions that match topic names that should be replicated. MirrorMaker will replicate these topics if they are not matched by &quot;topics.blacklist&quot;. Currently defaults to [&quot;.*&quot;].
-	*/
-	TopicsBlacklist []string `json:"topics.blacklist,omitempty"` // Topic or topic regular expression matching topic
+	Topics                          []string                     `json:"topics,omitempty"`                              // List of topics and/or regular expressions to replicate. Topic names and regular expressions that match topic names that should be replicated. MirrorMaker will replicate these topics if they are not matched by &quot;topics.blacklist&quot;. Currently defaults to [&quot;.*&quot;].
+	TopicsBlacklist                 []string                     `json:"topics.blacklist,omitempty"`                    // Topic or topic regular expression matching topic
 }
 type ReplicationPolicyClassType string
 
@@ -155,12 +151,8 @@ type ServiceKafkaMirrorMakerCreateReplicationFlowIn struct {
 	SyncGroupOffsetsEnabled         *bool                        `json:"sync_group_offsets_enabled,omitempty"`          // Sync consumer group offsets
 	SyncGroupOffsetsIntervalSeconds *int                         `json:"sync_group_offsets_interval_seconds,omitempty"` // Frequency of consumer group offset sync
 	TargetCluster                   string                       `json:"target_cluster"`                                // Target cluster alias
-	Topics                          *[]string                    `json:"topics,omitempty"`                              /*
-		List of topics and/or regular expressions to replicate.
-
-		Topic names and regular expressions that match topic names that should be replicated. MirrorMaker will replicate these topics if they are not matched by &quot;topics.blacklist&quot;. Currently defaults to [&quot;.*&quot;].
-	*/
-	TopicsBlacklist *[]string `json:"topics.blacklist,omitempty"` // Topic or topic regular expression matching topic
+	Topics                          *[]string                    `json:"topics,omitempty"`                              // List of topics and/or regular expressions to replicate. Topic names and regular expressions that match topic names that should be replicated. MirrorMaker will replicate these topics if they are not matched by &quot;topics.blacklist&quot;. Currently defaults to [&quot;.*&quot;].
+	TopicsBlacklist                 *[]string                    `json:"topics.blacklist,omitempty"`                    // Topic or topic regular expression matching topic
 }
 
 // ServiceKafkaMirrorMakerGetReplicationFlowOut Replication flow
@@ -178,12 +170,8 @@ type ServiceKafkaMirrorMakerGetReplicationFlowOut struct {
 	SyncGroupOffsetsEnabled         *bool                        `json:"sync_group_offsets_enabled,omitempty"`          // Sync consumer group offsets
 	SyncGroupOffsetsIntervalSeconds *int                         `json:"sync_group_offsets_interval_seconds,omitempty"` // Frequency of consumer group offset sync
 	TargetCluster                   string                       `json:"target_cluster"`                                // Target cluster alias
-	Topics                          []string                     `json:"topics,omitempty"`                              /*
-		List of topics and/or regular expressions to replicate.
-
-		Topic names and regular expressions that match topic names that should be replicated. MirrorMaker will replicate these topics if they are not matched by &quot;topics.blacklist&quot;. Currently defaults to [&quot;.*&quot;].
-	*/
-	TopicsBlacklist []string `json:"topics.blacklist,omitempty"` // Topic or topic regular expression matching topic
+	Topics                          []string                     `json:"topics,omitempty"`                              // List of topics and/or regular expressions to replicate. Topic names and regular expressions that match topic names that should be replicated. MirrorMaker will replicate these topics if they are not matched by &quot;topics.blacklist&quot;. Currently defaults to [&quot;.*&quot;].
+	TopicsBlacklist                 []string                     `json:"topics.blacklist,omitempty"`                    // Topic or topic regular expression matching topic
 }
 
 // ServiceKafkaMirrorMakerPatchReplicationFlowIn ServiceKafkaMirrorMakerPatchReplicationFlowRequestBody
@@ -198,12 +186,8 @@ type ServiceKafkaMirrorMakerPatchReplicationFlowIn struct {
 	ReplicationPolicyClass          ReplicationPolicyClassType   `json:"replication_policy_class,omitempty"`            // Replication policy class
 	SyncGroupOffsetsEnabled         *bool                        `json:"sync_group_offsets_enabled,omitempty"`          // Sync consumer group offsets
 	SyncGroupOffsetsIntervalSeconds *int                         `json:"sync_group_offsets_interval_seconds,omitempty"` // Frequency of consumer group offset sync
-	Topics                          *[]string                    `json:"topics,omitempty"`                              /*
-		List of topics and/or regular expressions to replicate.
-
-		Topic names and regular expressions that match topic names that should be replicated. MirrorMaker will replicate these topics if they are not matched by &quot;topics.blacklist&quot;. Currently defaults to [&quot;.*&quot;].
-	*/
-	TopicsBlacklist *[]string `json:"topics.blacklist,omitempty"` // Topic or topic regular expression matching topic
+	Topics                          *[]string                    `json:"topics,omitempty"`                              // List of topics and/or regular expressions to replicate. Topic names and regular expressions that match topic names that should be replicated. MirrorMaker will replicate these topics if they are not matched by &quot;topics.blacklist&quot;. Currently defaults to [&quot;.*&quot;].
+	TopicsBlacklist                 *[]string                    `json:"topics.blacklist,omitempty"`                    // Topic or topic regular expression matching topic
 }
 
 // ServiceKafkaMirrorMakerPatchReplicationFlowOut Replication flow
@@ -221,12 +205,8 @@ type ServiceKafkaMirrorMakerPatchReplicationFlowOut struct {
 	SyncGroupOffsetsEnabled         *bool                        `json:"sync_group_offsets_enabled,omitempty"`          // Sync consumer group offsets
 	SyncGroupOffsetsIntervalSeconds *int                         `json:"sync_group_offsets_interval_seconds,omitempty"` // Frequency of consumer group offset sync
 	TargetCluster                   string                       `json:"target_cluster"`                                // Target cluster alias
-	Topics                          []string                     `json:"topics,omitempty"`                              /*
-		List of topics and/or regular expressions to replicate.
-
-		Topic names and regular expressions that match topic names that should be replicated. MirrorMaker will replicate these topics if they are not matched by &quot;topics.blacklist&quot;. Currently defaults to [&quot;.*&quot;].
-	*/
-	TopicsBlacklist []string `json:"topics.blacklist,omitempty"` // Topic or topic regular expression matching topic
+	Topics                          []string                     `json:"topics,omitempty"`                              // List of topics and/or regular expressions to replicate. Topic names and regular expressions that match topic names that should be replicated. MirrorMaker will replicate these topics if they are not matched by &quot;topics.blacklist&quot;. Currently defaults to [&quot;.*&quot;].
+	TopicsBlacklist                 []string                     `json:"topics.blacklist,omitempty"`                    // Topic or topic regular expression matching topic
 }
 
 // serviceKafkaMirrorMakerGetReplicationFlowOut ServiceKafkaMirrorMakerGetReplicationFlowResponse
@@ -236,11 +216,7 @@ type serviceKafkaMirrorMakerGetReplicationFlowOut struct {
 
 // serviceKafkaMirrorMakerGetReplicationFlowsOut ServiceKafkaMirrorMakerGetReplicationFlowsResponse
 type serviceKafkaMirrorMakerGetReplicationFlowsOut struct {
-	ReplicationFlows []ReplicationFlowOut `json:"replication_flows"` /*
-		Replication flows
-
-		Describes data replication flows between Kafka clusters
-	*/
+	ReplicationFlows []ReplicationFlowOut `json:"replication_flows"` // Replication flows. Describes data replication flows between Kafka clusters
 }
 
 // serviceKafkaMirrorMakerPatchReplicationFlowOut ServiceKafkaMirrorMakerPatchReplicationFlowResponse

--- a/handler/privatelink/privatelink.go
+++ b/handler/privatelink/privatelink.go
@@ -290,23 +290,15 @@ type PrivatelinkAvailabilityOut struct {
 
 // ServicePrivatelinkAwscreateIn ServicePrivatelinkAWSCreateRequestBody
 type ServicePrivatelinkAwscreateIn struct {
-	Principals []string `json:"principals"` /*
-		ARN allowlist
-
-		ARNs of principals allowed connecting to the service
-	*/
+	Principals []string `json:"principals"` // ARN allowlist. ARNs of principals allowed connecting to the service
 }
 
 // ServicePrivatelinkAwscreateOut ServicePrivatelinkAWSCreateResponse
 type ServicePrivatelinkAwscreateOut struct {
-	AwsServiceId   *string  `json:"aws_service_id,omitempty"`   // AWS VPC endpoint service ID
-	AwsServiceName *string  `json:"aws_service_name,omitempty"` // AWS VPC endpoint service name
-	Principals     []string `json:"principals"`                 /*
-		ARN allowlist
-
-		ARNs of principals allowed connecting to the service
-	*/
-	State ServicePrivatelinkAwscreateStateType `json:"state"` // Privatelink resource state
+	AwsServiceId   *string                              `json:"aws_service_id,omitempty"`   // AWS VPC endpoint service ID
+	AwsServiceName *string                              `json:"aws_service_name,omitempty"` // AWS VPC endpoint service name
+	Principals     []string                             `json:"principals"`                 // ARN allowlist. ARNs of principals allowed connecting to the service
+	State          ServicePrivatelinkAwscreateStateType `json:"state"`                      // Privatelink resource state
 }
 type ServicePrivatelinkAwscreateStateType string
 
@@ -322,14 +314,10 @@ func ServicePrivatelinkAwscreateStateTypeChoices() []string {
 
 // ServicePrivatelinkAwsdeleteOut ServicePrivatelinkAWSDeleteResponse
 type ServicePrivatelinkAwsdeleteOut struct {
-	AwsServiceId   *string  `json:"aws_service_id,omitempty"`   // AWS VPC endpoint service ID
-	AwsServiceName *string  `json:"aws_service_name,omitempty"` // AWS VPC endpoint service name
-	Principals     []string `json:"principals"`                 /*
-		ARN allowlist
-
-		ARNs of principals allowed connecting to the service
-	*/
-	State ServicePrivatelinkAwsdeleteStateType `json:"state"` // Privatelink resource state
+	AwsServiceId   *string                              `json:"aws_service_id,omitempty"`   // AWS VPC endpoint service ID
+	AwsServiceName *string                              `json:"aws_service_name,omitempty"` // AWS VPC endpoint service name
+	Principals     []string                             `json:"principals"`                 // ARN allowlist. ARNs of principals allowed connecting to the service
+	State          ServicePrivatelinkAwsdeleteStateType `json:"state"`                      // Privatelink resource state
 }
 type ServicePrivatelinkAwsdeleteStateType string
 
@@ -345,14 +333,10 @@ func ServicePrivatelinkAwsdeleteStateTypeChoices() []string {
 
 // ServicePrivatelinkAwsgetOut ServicePrivatelinkAWSGetResponse
 type ServicePrivatelinkAwsgetOut struct {
-	AwsServiceId   *string  `json:"aws_service_id,omitempty"`   // AWS VPC endpoint service ID
-	AwsServiceName *string  `json:"aws_service_name,omitempty"` // AWS VPC endpoint service name
-	Principals     []string `json:"principals"`                 /*
-		ARN allowlist
-
-		ARNs of principals allowed connecting to the service
-	*/
-	State ServicePrivatelinkAwsgetStateType `json:"state"` // Privatelink resource state
+	AwsServiceId   *string                           `json:"aws_service_id,omitempty"`   // AWS VPC endpoint service ID
+	AwsServiceName *string                           `json:"aws_service_name,omitempty"` // AWS VPC endpoint service name
+	Principals     []string                          `json:"principals"`                 // ARN allowlist. ARNs of principals allowed connecting to the service
+	State          ServicePrivatelinkAwsgetStateType `json:"state"`                      // Privatelink resource state
 }
 type ServicePrivatelinkAwsgetStateType string
 
@@ -368,23 +352,15 @@ func ServicePrivatelinkAwsgetStateTypeChoices() []string {
 
 // ServicePrivatelinkAwsupdateIn ServicePrivatelinkAWSUpdateRequestBody
 type ServicePrivatelinkAwsupdateIn struct {
-	Principals []string `json:"principals"` /*
-		ARN allowlist
-
-		ARNs of principals allowed connecting to the service
-	*/
+	Principals []string `json:"principals"` // ARN allowlist. ARNs of principals allowed connecting to the service
 }
 
 // ServicePrivatelinkAwsupdateOut ServicePrivatelinkAWSUpdateResponse
 type ServicePrivatelinkAwsupdateOut struct {
-	AwsServiceId   *string  `json:"aws_service_id,omitempty"`   // AWS VPC endpoint service ID
-	AwsServiceName *string  `json:"aws_service_name,omitempty"` // AWS VPC endpoint service name
-	Principals     []string `json:"principals"`                 /*
-		ARN allowlist
-
-		ARNs of principals allowed connecting to the service
-	*/
-	State ServicePrivatelinkAwsupdateStateType `json:"state"` // Privatelink resource state
+	AwsServiceId   *string                              `json:"aws_service_id,omitempty"`   // AWS VPC endpoint service ID
+	AwsServiceName *string                              `json:"aws_service_name,omitempty"` // AWS VPC endpoint service name
+	Principals     []string                             `json:"principals"`                 // ARN allowlist. ARNs of principals allowed connecting to the service
+	State          ServicePrivatelinkAwsupdateStateType `json:"state"`                      // Privatelink resource state
 }
 type ServicePrivatelinkAwsupdateStateType string
 
@@ -446,11 +422,7 @@ type ServicePrivatelinkAzureConnectionUpdateOut struct {
 
 // ServicePrivatelinkAzureCreateIn ServicePrivatelinkAzureCreateRequestBody
 type ServicePrivatelinkAzureCreateIn struct {
-	UserSubscriptionIds []string `json:"user_subscription_ids"` /*
-		Subscription ID allowlist
-
-		IDs of Azure subscriptions allowed to connect to the service
-	*/
+	UserSubscriptionIds []string `json:"user_subscription_ids"` // Subscription ID allowlist. IDs of Azure subscriptions allowed to connect to the service
 }
 
 // ServicePrivatelinkAzureCreateOut ServicePrivatelinkAzureCreateResponse
@@ -458,11 +430,7 @@ type ServicePrivatelinkAzureCreateOut struct {
 	AzureServiceAlias   *string                          `json:"azure_service_alias,omitempty"` // Azure Privatelink service alias
 	AzureServiceId      *string                          `json:"azure_service_id,omitempty"`    // Azure Privatelink service ID
 	State               ServicePrivatelinkAzureStateType `json:"state"`                         // Privatelink resource state
-	UserSubscriptionIds []string                         `json:"user_subscription_ids"`         /*
-		Subscription ID allowlist
-
-		IDs of Azure subscriptions allowed to connect to the service
-	*/
+	UserSubscriptionIds []string                         `json:"user_subscription_ids"`         // Subscription ID allowlist. IDs of Azure subscriptions allowed to connect to the service
 }
 
 // ServicePrivatelinkAzureDeleteOut ServicePrivatelinkAzureDeleteResponse
@@ -470,11 +438,7 @@ type ServicePrivatelinkAzureDeleteOut struct {
 	AzureServiceAlias   *string                          `json:"azure_service_alias,omitempty"` // Azure Privatelink service alias
 	AzureServiceId      *string                          `json:"azure_service_id,omitempty"`    // Azure Privatelink service ID
 	State               ServicePrivatelinkAzureStateType `json:"state"`                         // Privatelink resource state
-	UserSubscriptionIds []string                         `json:"user_subscription_ids"`         /*
-		Subscription ID allowlist
-
-		IDs of Azure subscriptions allowed to connect to the service
-	*/
+	UserSubscriptionIds []string                         `json:"user_subscription_ids"`         // Subscription ID allowlist. IDs of Azure subscriptions allowed to connect to the service
 }
 
 // ServicePrivatelinkAzureGetOut ServicePrivatelinkAzureGetResponse
@@ -482,11 +446,7 @@ type ServicePrivatelinkAzureGetOut struct {
 	AzureServiceAlias   *string                          `json:"azure_service_alias,omitempty"` // Azure Privatelink service alias
 	AzureServiceId      *string                          `json:"azure_service_id,omitempty"`    // Azure Privatelink service ID
 	State               ServicePrivatelinkAzureStateType `json:"state"`                         // Privatelink resource state
-	UserSubscriptionIds []string                         `json:"user_subscription_ids"`         /*
-		Subscription ID allowlist
-
-		IDs of Azure subscriptions allowed to connect to the service
-	*/
+	UserSubscriptionIds []string                         `json:"user_subscription_ids"`         // Subscription ID allowlist. IDs of Azure subscriptions allowed to connect to the service
 }
 type ServicePrivatelinkAzureStateType string
 
@@ -502,11 +462,7 @@ func ServicePrivatelinkAzureStateTypeChoices() []string {
 
 // ServicePrivatelinkAzureUpdateIn ServicePrivatelinkAzureUpdateRequestBody
 type ServicePrivatelinkAzureUpdateIn struct {
-	UserSubscriptionIds []string `json:"user_subscription_ids"` /*
-		Subscription ID allowlist
-
-		IDs of Azure subscriptions allowed to connect to the service
-	*/
+	UserSubscriptionIds []string `json:"user_subscription_ids"` // Subscription ID allowlist. IDs of Azure subscriptions allowed to connect to the service
 }
 
 // ServicePrivatelinkAzureUpdateOut ServicePrivatelinkAzureUpdateResponse
@@ -514,11 +470,7 @@ type ServicePrivatelinkAzureUpdateOut struct {
 	AzureServiceAlias   *string                          `json:"azure_service_alias,omitempty"` // Azure Privatelink service alias
 	AzureServiceId      *string                          `json:"azure_service_id,omitempty"`    // Azure Privatelink service ID
 	State               ServicePrivatelinkAzureStateType `json:"state"`                         // Privatelink resource state
-	UserSubscriptionIds []string                         `json:"user_subscription_ids"`         /*
-		Subscription ID allowlist
-
-		IDs of Azure subscriptions allowed to connect to the service
-	*/
+	UserSubscriptionIds []string                         `json:"user_subscription_ids"`         // Subscription ID allowlist. IDs of Azure subscriptions allowed to connect to the service
 }
 
 // publicPrivatelinkAvailabilityListOut PublicPrivatelinkAvailabilityListResponse

--- a/handler/service/service.go
+++ b/handler/service/service.go
@@ -517,11 +517,7 @@ func (h *ServiceHandler) ServiceUpdate(ctx context.Context, project string, serv
 	return &out.Service, nil
 }
 
-/*
-AccessControlOut Service specific access controls for user
-
-Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
-*/
+// AccessControlOut Service specific access controls for user. Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
 type AccessControlOut struct {
 	DragonflyAclCategories []string `json:"dragonfly_acl_categories,omitempty"` // Command category rules
 	DragonflyAclCommands   []string `json:"dragonfly_acl_commands,omitempty"`   // Rules for individual commands
@@ -529,13 +525,9 @@ type AccessControlOut struct {
 	M3Group                *string  `json:"m3_group,omitempty"`                 // M3 access group to associate users with
 	PgAllowReplication     *bool    `json:"pg_allow_replication,omitempty"`     // Enable REPLICATION role option
 	RedisAclCategories     []string `json:"redis_acl_categories,omitempty"`     // Command category rules
-	RedisAclChannels       []string `json:"redis_acl_channels,omitempty"`       /*
-		Permitted pub/sub channel patterns
-
-		Glob-style patterns defining which pub/sub channels can be accessed. If array is not defined, the default policy is used (allchannels).
-	*/
-	RedisAclCommands []string `json:"redis_acl_commands,omitempty"` // Rules for individual commands
-	RedisAclKeys     []string `json:"redis_acl_keys,omitempty"`     // Key access rules
+	RedisAclChannels       []string `json:"redis_acl_channels,omitempty"`       // Permitted pub/sub channel patterns. Glob-style patterns defining which pub/sub channels can be accessed. If array is not defined, the default policy is used (allchannels).
+	RedisAclCommands       []string `json:"redis_acl_commands,omitempty"`       // Rules for individual commands
+	RedisAclKeys           []string `json:"redis_acl_keys,omitempty"`           // Key access rules
 }
 type AclOut struct {
 	Id         *string        `json:"id,omitempty"` // ID
@@ -1730,13 +1722,9 @@ func UsageTypeChoices() []string {
 }
 
 type UserOut struct {
-	AccessCert                  *string           `json:"access_cert,omitempty"`                      // Access certificate for TLS client authentication
-	AccessCertNotValidAfterTime *time.Time        `json:"access_cert_not_valid_after_time,omitempty"` // Validity end time (ISO8601) for the current access certificate
-	AccessControl               *AccessControlOut `json:"access_control,omitempty"`                   /*
-		Service specific access controls for user
-
-		Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
-	*/
+	AccessCert                    *string            `json:"access_cert,omitempty"`                        // Access certificate for TLS client authentication
+	AccessCertNotValidAfterTime   *time.Time         `json:"access_cert_not_valid_after_time,omitempty"`   // Validity end time (ISO8601) for the current access certificate
+	AccessControl                 *AccessControlOut  `json:"access_control,omitempty"`                     // Service specific access controls for user. Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
 	AccessKey                     *string            `json:"access_key,omitempty"`                         // Access key for TLS client authentication
 	Authentication                AuthenticationType `json:"authentication,omitempty"`                     // Authentication details
 	ExpiringCertNotValidAfterTime *time.Time         `json:"expiring_cert_not_valid_after_time,omitempty"` // Validity end time (ISO8601) for the expiring access certificate

--- a/handler/serviceuser/serviceuser.go
+++ b/handler/serviceuser/serviceuser.go
@@ -107,11 +107,7 @@ func (h *ServiceUserHandler) ServiceUserGet(ctx context.Context, project string,
 	return &out.User, nil
 }
 
-/*
-AccessControlIn Service specific access controls for user
-
-Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
-*/
+// AccessControlIn Service specific access controls for user. Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
 type AccessControlIn struct {
 	DragonflyAclCategories *[]string `json:"dragonfly_acl_categories,omitempty"` // Command category rules
 	DragonflyAclCommands   *[]string `json:"dragonfly_acl_commands,omitempty"`   // Rules for individual commands
@@ -119,20 +115,12 @@ type AccessControlIn struct {
 	M3Group                *string   `json:"m3_group,omitempty"`                 // M3 access group to associate users with
 	PgAllowReplication     *bool     `json:"pg_allow_replication,omitempty"`     // Enable REPLICATION role option
 	RedisAclCategories     *[]string `json:"redis_acl_categories,omitempty"`     // Command category rules
-	RedisAclChannels       *[]string `json:"redis_acl_channels,omitempty"`       /*
-		Permitted pub/sub channel patterns
-
-		Glob-style patterns defining which pub/sub channels can be accessed. If array is not defined, the default policy is used (allchannels).
-	*/
-	RedisAclCommands *[]string `json:"redis_acl_commands,omitempty"` // Rules for individual commands
-	RedisAclKeys     *[]string `json:"redis_acl_keys,omitempty"`     // Key access rules
+	RedisAclChannels       *[]string `json:"redis_acl_channels,omitempty"`       // Permitted pub/sub channel patterns. Glob-style patterns defining which pub/sub channels can be accessed. If array is not defined, the default policy is used (allchannels).
+	RedisAclCommands       *[]string `json:"redis_acl_commands,omitempty"`       // Rules for individual commands
+	RedisAclKeys           *[]string `json:"redis_acl_keys,omitempty"`           // Key access rules
 }
 
-/*
-AccessControlOut Service specific access controls for user
-
-Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
-*/
+// AccessControlOut Service specific access controls for user. Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
 type AccessControlOut struct {
 	DragonflyAclCategories []string `json:"dragonfly_acl_categories,omitempty"` // Command category rules
 	DragonflyAclCommands   []string `json:"dragonfly_acl_commands,omitempty"`   // Rules for individual commands
@@ -140,13 +128,9 @@ type AccessControlOut struct {
 	M3Group                *string  `json:"m3_group,omitempty"`                 // M3 access group to associate users with
 	PgAllowReplication     *bool    `json:"pg_allow_replication,omitempty"`     // Enable REPLICATION role option
 	RedisAclCategories     []string `json:"redis_acl_categories,omitempty"`     // Command category rules
-	RedisAclChannels       []string `json:"redis_acl_channels,omitempty"`       /*
-		Permitted pub/sub channel patterns
-
-		Glob-style patterns defining which pub/sub channels can be accessed. If array is not defined, the default policy is used (allchannels).
-	*/
-	RedisAclCommands []string `json:"redis_acl_commands,omitempty"` // Rules for individual commands
-	RedisAclKeys     []string `json:"redis_acl_keys,omitempty"`     // Key access rules
+	RedisAclChannels       []string `json:"redis_acl_channels,omitempty"`       // Permitted pub/sub channel patterns. Glob-style patterns defining which pub/sub channels can be accessed. If array is not defined, the default policy is used (allchannels).
+	RedisAclCommands       []string `json:"redis_acl_commands,omitempty"`       // Rules for individual commands
+	RedisAclKeys           []string `json:"redis_acl_keys,omitempty"`           // Key access rules
 }
 type AclOut struct {
 	Id         *string        `json:"id,omitempty"` // ID
@@ -470,24 +454,16 @@ func ServiceStateTypeChoices() []string {
 
 // ServiceUserCreateIn ServiceUserCreateRequestBody
 type ServiceUserCreateIn struct {
-	AccessControl *AccessControlIn `json:"access_control,omitempty"` /*
-		Service specific access controls for user
-
-		Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
-	*/
+	AccessControl  *AccessControlIn   `json:"access_control,omitempty"` // Service specific access controls for user. Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
 	Authentication AuthenticationType `json:"authentication,omitempty"` // Authentication details
 	Username       string             `json:"username"`                 // Service username
 }
 
 // ServiceUserCreateOut Service user account
 type ServiceUserCreateOut struct {
-	AccessCert                  *string           `json:"access_cert,omitempty"`                      // Access certificate for TLS client authentication
-	AccessCertNotValidAfterTime *time.Time        `json:"access_cert_not_valid_after_time,omitempty"` // Validity end time (ISO8601) for the current access certificate
-	AccessControl               *AccessControlOut `json:"access_control,omitempty"`                   /*
-		Service specific access controls for user
-
-		Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
-	*/
+	AccessCert                    *string            `json:"access_cert,omitempty"`                        // Access certificate for TLS client authentication
+	AccessCertNotValidAfterTime   *time.Time         `json:"access_cert_not_valid_after_time,omitempty"`   // Validity end time (ISO8601) for the current access certificate
+	AccessControl                 *AccessControlOut  `json:"access_control,omitempty"`                     // Service specific access controls for user. Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
 	AccessKey                     *string            `json:"access_key,omitempty"`                         // Access key for TLS client authentication
 	Authentication                AuthenticationType `json:"authentication,omitempty"`                     // Authentication details
 	ExpiringCertNotValidAfterTime *time.Time         `json:"expiring_cert_not_valid_after_time,omitempty"` // Validity end time (ISO8601) for the expiring access certificate
@@ -498,11 +474,7 @@ type ServiceUserCreateOut struct {
 
 // ServiceUserCredentialsModifyIn ServiceUserCredentialsModifyRequestBody
 type ServiceUserCredentialsModifyIn struct {
-	AccessControl *AccessControlIn `json:"access_control,omitempty"` /*
-		Service specific access controls for user
-
-		Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
-	*/
+	AccessControl  *AccessControlIn   `json:"access_control,omitempty"` // Service specific access controls for user. Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
 	Authentication AuthenticationType `json:"authentication,omitempty"` // Authentication details
 	NewPassword    *string            `json:"new_password,omitempty"`   // New password
 	Operation      OperationType      `json:"operation"`                // Operation type
@@ -590,13 +562,9 @@ type ServiceUserCredentialsResetOut struct {
 
 // ServiceUserGetOut Service user account
 type ServiceUserGetOut struct {
-	AccessCert                  *string           `json:"access_cert,omitempty"`                      // Access certificate for TLS client authentication
-	AccessCertNotValidAfterTime *time.Time        `json:"access_cert_not_valid_after_time,omitempty"` // Validity end time (ISO8601) for the current access certificate
-	AccessControl               *AccessControlOut `json:"access_control,omitempty"`                   /*
-		Service specific access controls for user
-
-		Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
-	*/
+	AccessCert                    *string            `json:"access_cert,omitempty"`                        // Access certificate for TLS client authentication
+	AccessCertNotValidAfterTime   *time.Time         `json:"access_cert_not_valid_after_time,omitempty"`   // Validity end time (ISO8601) for the current access certificate
+	AccessControl                 *AccessControlOut  `json:"access_control,omitempty"`                     // Service specific access controls for user. Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
 	AccessKey                     *string            `json:"access_key,omitempty"`                         // Access key for TLS client authentication
 	Authentication                AuthenticationType `json:"authentication,omitempty"`                     // Authentication details
 	ExpiringCertNotValidAfterTime *time.Time         `json:"expiring_cert_not_valid_after_time,omitempty"` // Validity end time (ISO8601) for the expiring access certificate
@@ -674,13 +642,9 @@ func UsageTypeChoices() []string {
 }
 
 type UserOut struct {
-	AccessCert                  *string           `json:"access_cert,omitempty"`                      // Access certificate for TLS client authentication
-	AccessCertNotValidAfterTime *time.Time        `json:"access_cert_not_valid_after_time,omitempty"` // Validity end time (ISO8601) for the current access certificate
-	AccessControl               *AccessControlOut `json:"access_control,omitempty"`                   /*
-		Service specific access controls for user
-
-		Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
-	*/
+	AccessCert                    *string            `json:"access_cert,omitempty"`                        // Access certificate for TLS client authentication
+	AccessCertNotValidAfterTime   *time.Time         `json:"access_cert_not_valid_after_time,omitempty"`   // Validity end time (ISO8601) for the current access certificate
+	AccessControl                 *AccessControlOut  `json:"access_control,omitempty"`                     // Service specific access controls for user. Service type specific access control rules for user. Currently only used for configuring user ACLs for Redis version 6 and above.
 	AccessKey                     *string            `json:"access_key,omitempty"`                         // Access key for TLS client authentication
 	Authentication                AuthenticationType `json:"authentication,omitempty"`                     // Authentication details
 	ExpiringCertNotValidAfterTime *time.Time         `json:"expiring_cert_not_valid_after_time,omitempty"` // Validity end time (ISO8601) for the expiring access certificate


### PR DESCRIPTION
Multiline comments look weird on fields. 
Flattens the into a single line.