### PR TITLE
feat: fix linter deprecation warnings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,7 +16,7 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - gomnd
+    - mnd
     - gosec
     - gosimple
     - govet

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,6 +27,7 @@ linters:
     - nakedret
     - nestif
     - nilerr
+    - nolintlint
     - prealloc
     - revive
     - staticcheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -42,7 +42,9 @@ linters-settings:
     min-len: 2
     min-occurrences: 2
   govet:
-    check-shadowing: true
+    enable-all: true
+    disable:
+      - fieldalignment
   lll:
     line-length: 120
     tab-width: 4

--- a/generator/main.go
+++ b/generator/main.go
@@ -67,7 +67,7 @@ const (
 	queryParamArraySize  = 2
 )
 
-// nolint:funlen,gocognit,gocyclo // It's a generator, it's supposed to be long, and we won't expand it.
+//nolint:funlen,gocognit,gocyclo // It's a generator, it's supposed to be long, and we won't expand it.
 func exec() error {
 	cfg := new(envConfig)
 
@@ -463,9 +463,8 @@ func exec() error {
 // reMakesSense sometimes there are invalid enums, for instance just a comma ","
 var reMakesSense = regexp.MustCompile(`\w`)
 
-// nolint:funlen // It's a generator, it's supposed to be long, and we won't expand it.
+//nolint:funlen // It's a generator, it's supposed to be long, and we won't expand it.
 func writeStruct(f *jen.File, s *Schema) error {
-	// nolint:nestif // It's a generator, it's supposed to be long, and we won't expand it.
 	if s.isEnum() {
 		kind := getScalarType(s)
 		o := f.Type().Id(s.CamelName)

--- a/generator/main.go
+++ b/generator/main.go
@@ -422,7 +422,6 @@ func exec() error {
 		for _, k := range sortedKeys(scope) {
 			v := scope[k]
 			err = writeStruct(file, v)
-
 			if err != nil {
 				return err
 			}
@@ -430,7 +429,7 @@ func exec() error {
 
 		dirPath := filepath.Join(cfg.HandlerDir, fileName)
 
-		err = os.MkdirAll(dirPath, os.ModePerm)
+		err = os.MkdirAll(dirPath, dirMode)
 		if err != nil {
 			return err
 		}
@@ -562,7 +561,8 @@ func toSingle(src string) string {
 
 const (
 	yamlTabSize = 2
-	writeMode   = os.FileMode(0644)
+	writeMode   = os.FileMode(0o644)
+	dirMode     = os.FileMode(0o750)
 )
 
 // readConfig reads and formats the config

--- a/generator/models.go
+++ b/generator/models.go
@@ -151,7 +151,7 @@ type Schema struct {
 	in, out       bool // Request or Response DTO
 }
 
-// nolint:funlen,gocognit,gocyclo // It is easy to maintain and read, we don't need to split it
+//nolint:funlen,gocognit,gocyclo // It is easy to maintain and read, we don't need to split it
 func (s *Schema) init(doc *Doc, scope map[string]*Schema, name string) {
 	if s.Ref != "" {
 		other, err := doc.getSchema(s.Ref)


### PR DESCRIPTION
## About this change - What it does

Fixes deprecated golangci-lint linters and options

## Why this way

No more deprecation warnings
