### PR TITLE
feat: add service plan APIs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -231,6 +231,11 @@ Project:
   - ProjectKmsGetCA
   - ProjectList
   - ProjectPrivatelinkAvailabilityList
+  - ProjectServicePlanList
+  - ProjectServicePlanPriceGet
+  - ProjectServicePlanSpecsGet
+  - ProjectServiceTypesGet
+  - ProjectServiceTypesList
   - ProjectTagsList
   - ProjectTagsReplace
   - ProjectTagsUpdate

--- a/handler/kafkaschemaregistry/kafkaschemaregistry.go
+++ b/handler/kafkaschemaregistry/kafkaschemaregistry.go
@@ -68,7 +68,7 @@ type Handler interface {
 	// ServiceSchemaRegistrySubjectVersionGet get Schema Registry Subject version
 	// GET /v1/project/{project}/service/{service_name}/kafka/schema/subjects/{subject_name}/versions/{version_id}
 	// https://api.aiven.io/doc/#tag/Service:_Kafka/operation/ServiceSchemaRegistrySubjectVersionGet
-	ServiceSchemaRegistrySubjectVersionGet(ctx context.Context, project string, serviceName string, subjectName string, versionId int) error
+	ServiceSchemaRegistrySubjectVersionGet(ctx context.Context, project string, serviceName string, subjectName string, versionId int) (*ServiceSchemaRegistrySubjectVersionGetOut, error)
 
 	// ServiceSchemaRegistrySubjectVersionPost register a new Schema in Schema Registry
 	// POST /v1/project/{project}/service/{service_name}/kafka/schema/subjects/{subject_name}/versions
@@ -223,10 +223,18 @@ func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistrySubjectVersionDelete(c
 	_, err := h.doer.Do(ctx, "ServiceSchemaRegistrySubjectVersionDelete", "DELETE", path, nil)
 	return err
 }
-func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistrySubjectVersionGet(ctx context.Context, project string, serviceName string, subjectName string, versionId int) error {
+func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistrySubjectVersionGet(ctx context.Context, project string, serviceName string, subjectName string, versionId int) (*ServiceSchemaRegistrySubjectVersionGetOut, error) {
 	path := fmt.Sprintf("/v1/project/%s/service/%s/kafka/schema/subjects/%s/versions/%d", url.PathEscape(project), url.PathEscape(serviceName), url.PathEscape(subjectName), versionId)
-	_, err := h.doer.Do(ctx, "ServiceSchemaRegistrySubjectVersionGet", "GET", path, nil)
-	return err
+	b, err := h.doer.Do(ctx, "ServiceSchemaRegistrySubjectVersionGet", "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	out := new(serviceSchemaRegistrySubjectVersionGetOut)
+	err = json.Unmarshal(b, out)
+	if err != nil {
+		return nil, err
+	}
+	return &out.Version, nil
 }
 func (h *KafkaSchemaRegistryHandler) ServiceSchemaRegistrySubjectVersionPost(ctx context.Context, project string, serviceName string, subjectName string, in *ServiceSchemaRegistrySubjectVersionPostIn) (int, error) {
 	path := fmt.Sprintf("/v1/project/%s/service/%s/kafka/schema/subjects/%s/versions", url.PathEscape(project), url.PathEscape(serviceName), url.PathEscape(subjectName))
@@ -311,6 +319,11 @@ type ReferenceIn struct {
 	Subject string `json:"subject"`
 	Version int    `json:"version"`
 }
+type ReferenceOut struct {
+	Name    string `json:"name"`
+	Subject string `json:"subject"`
+	Version int    `json:"version"`
+}
 type SchemaType string
 
 const (
@@ -338,12 +351,22 @@ type ServiceSchemaRegistryCompatibilityIn struct {
 
 // ServiceSchemaRegistryGlobalConfigPutIn ServiceSchemaRegistryGlobalConfigPutRequestBody
 type ServiceSchemaRegistryGlobalConfigPutIn struct {
-	Compatibility CompatibilityType `json:"compatibility"` // Configuration
+	Compatibility CompatibilityType `json:"compatibility"` // Compatibility level
 }
 
 // ServiceSchemaRegistrySubjectConfigPutIn ServiceSchemaRegistrySubjectConfigPutRequestBody
 type ServiceSchemaRegistrySubjectConfigPutIn struct {
-	Compatibility CompatibilityType `json:"compatibility"` // Configuration
+	Compatibility CompatibilityType `json:"compatibility"` // Compatibility level
+}
+
+// ServiceSchemaRegistrySubjectVersionGetOut Version
+type ServiceSchemaRegistrySubjectVersionGetOut struct {
+	Id         int            `json:"id"`                   // Schema Id
+	References []ReferenceOut `json:"references,omitempty"` // Schema references
+	Schema     string         `json:"schema"`
+	SchemaType SchemaType     `json:"schemaType,omitempty"` // Schema type
+	Subject    string         `json:"subject"`
+	Version    int            `json:"version"`
 }
 
 // ServiceSchemaRegistrySubjectVersionPostIn ServiceSchemaRegistrySubjectVersionPostRequestBody
@@ -375,27 +398,32 @@ type serviceSchemaRegistryCompatibilityOut struct {
 
 // serviceSchemaRegistryGlobalConfigGetOut ServiceSchemaRegistryGlobalConfigGetResponse
 type serviceSchemaRegistryGlobalConfigGetOut struct {
-	CompatibilityLevel CompatibilityType `json:"compatibilityLevel"` // Configuration
+	CompatibilityLevel CompatibilityType `json:"compatibilityLevel"` // Compatibility level
 }
 
 // serviceSchemaRegistryGlobalConfigPutOut ServiceSchemaRegistryGlobalConfigPutResponse
 type serviceSchemaRegistryGlobalConfigPutOut struct {
-	Compatibility CompatibilityType `json:"compatibility"` // Configuration
+	Compatibility CompatibilityType `json:"compatibility"` // Compatibility level
 }
 
 // serviceSchemaRegistrySubjectConfigGetOut ServiceSchemaRegistrySubjectConfigGetResponse
 type serviceSchemaRegistrySubjectConfigGetOut struct {
-	CompatibilityLevel CompatibilityType `json:"compatibilityLevel"` // Configuration
+	CompatibilityLevel CompatibilityType `json:"compatibilityLevel"` // Compatibility level
 }
 
 // serviceSchemaRegistrySubjectConfigPutOut ServiceSchemaRegistrySubjectConfigPutResponse
 type serviceSchemaRegistrySubjectConfigPutOut struct {
-	Compatibility CompatibilityType `json:"compatibility"` // Configuration
+	Compatibility CompatibilityType `json:"compatibility"` // Compatibility level
+}
+
+// serviceSchemaRegistrySubjectVersionGetOut ServiceSchemaRegistrySubjectVersionGetResponse
+type serviceSchemaRegistrySubjectVersionGetOut struct {
+	Version ServiceSchemaRegistrySubjectVersionGetOut `json:"version"` // Version
 }
 
 // serviceSchemaRegistrySubjectVersionPostOut ServiceSchemaRegistrySubjectVersionPostResponse
 type serviceSchemaRegistrySubjectVersionPostOut struct {
-	Id int `json:"id"` // Version
+	Id int `json:"id"` // Schema Id
 }
 
 // serviceSchemaRegistrySubjectVersionsGetOut ServiceSchemaRegistrySubjectVersionsGetResponse

--- a/handler/kafkatopic/kafkatopic.go
+++ b/handler/kafkatopic/kafkatopic.go
@@ -570,11 +570,13 @@ type ServiceKafkaTopicCreateIn struct {
 	CleanupPolicy     CleanupPolicyType `json:"cleanup_policy,omitempty"`      // DEPRECATED: use config.cleanup_policy
 	Config            *ConfigIn         `json:"config,omitempty"`              // Kafka topic configuration
 	MinInsyncReplicas *int              `json:"min_insync_replicas,omitempty"` // DEPRECATED: use config.min_insync_replicas
+	OwnerUserGroupId  *string           `json:"owner_user_group_id,omitempty"` // The user group that owns this topic
 	Partitions        *int              `json:"partitions,omitempty"`          // Number of partitions
 	Replication       *int              `json:"replication,omitempty"`         // Number of replicas
 	RetentionBytes    *int              `json:"retention_bytes,omitempty"`     // DEPRECATED: use config.retention_bytes
 	RetentionHours    *int              `json:"retention_hours,omitempty"`     // DEPRECATED: use config.retention_ms
 	Tags              *[]TagIn          `json:"tags,omitempty"`                // Topic tags
+	TopicDescription  *string           `json:"topic_description,omitempty"`   // Topic description
 	TopicName         string            `json:"topic_name"`                    // Topic name
 }
 
@@ -583,12 +585,14 @@ type ServiceKafkaTopicGetOut struct {
 	CleanupPolicy     string         `json:"cleanup_policy"`      // DEPRECATED: use config.cleanup_policy
 	Config            ConfigOut      `json:"config"`              // Kafka topic configuration
 	MinInsyncReplicas int            `json:"min_insync_replicas"` // DEPRECATED: use config.min_insync_replicas
+	OwnerUserGroupId  string         `json:"owner_user_group_id"` // The user group that owns this topic
 	Partitions        []PartitionOut `json:"partitions"`          // Topic partitions
 	Replication       int            `json:"replication"`         // Number of replicas
 	RetentionBytes    int            `json:"retention_bytes"`     // DEPRECATED: use config.retention_bytes
 	RetentionHours    int            `json:"retention_hours"`     // DEPRECATED: use config.retention_ms
 	State             TopicStateType `json:"state"`               // Topic state
 	Tags              []TagOut       `json:"tags"`                // Topic tags
+	TopicDescription  string         `json:"topic_description"`   // Topic description
 	TopicName         string         `json:"topic_name"`          // Topic name
 }
 
@@ -621,11 +625,13 @@ type ServiceKafkaTopicMessageProduceOut struct {
 type ServiceKafkaTopicUpdateIn struct {
 	Config            *ConfigIn `json:"config,omitempty"`              // Kafka topic configuration
 	MinInsyncReplicas *int      `json:"min_insync_replicas,omitempty"` // DEPRECATED: use config.min_insync_replicas
+	OwnerUserGroupId  *string   `json:"owner_user_group_id,omitempty"` // The user group that owns this topic
 	Partitions        *int      `json:"partitions,omitempty"`          // Number of partitions
 	Replication       *int      `json:"replication,omitempty"`         // Number of replicas
 	RetentionBytes    *int      `json:"retention_bytes,omitempty"`     // DEPRECATED: use config.retention_bytes
 	RetentionHours    *int      `json:"retention_hours,omitempty"`     // DEPRECATED: use config.retention_ms
 	Tags              *[]TagIn  `json:"tags,omitempty"`                // Topic tags
+	TopicDescription  *string   `json:"topic_description,omitempty"`   // Topic description
 }
 type SourceType string
 
@@ -659,6 +665,7 @@ type TagOut struct {
 type TopicOut struct {
 	CleanupPolicy       string         `json:"cleanup_policy"`                  // cleanup.policy
 	MinInsyncReplicas   int            `json:"min_insync_replicas"`             // min.insync.replicas
+	OwnerUserGroupId    string         `json:"owner_user_group_id"`             // The user group that owns this topic
 	Partitions          int            `json:"partitions"`                      // Number of partitions
 	RemoteStorageEnable *bool          `json:"remote_storage_enable,omitempty"` // remote.storage.enable
 	Replication         int            `json:"replication"`                     // Number of replicas
@@ -666,6 +673,7 @@ type TopicOut struct {
 	RetentionHours      int            `json:"retention_hours"`                 // Retention period (hours)
 	State               TopicStateType `json:"state"`                           // Topic state
 	Tags                []TagOut       `json:"tags"`                            // Topic tags
+	TopicDescription    string         `json:"topic_description"`               // Topic description
 	TopicName           string         `json:"topic_name"`                      // Topic name
 }
 type TopicStateType string

--- a/handler/service/service.go
+++ b/handler/service/service.go
@@ -1801,10 +1801,13 @@ func UnitTypeChoices() []string {
 }
 
 type UpdateOut struct {
-	Deadline    *string    `json:"deadline,omitempty"`    // Deadline for installing the update
-	Description *string    `json:"description,omitempty"` // Description of the update
-	StartAfter  *string    `json:"start_after,omitempty"` // The earliest time the update will be automatically applied
-	StartAt     *time.Time `json:"start_at,omitempty"`    // The time when the update will be automatically applied
+	Deadline           *string    `json:"deadline,omitempty"`             // Deadline for installing the update
+	Description        *string    `json:"description,omitempty"`          // Description of the update
+	DocumentationLink  *string    `json:"documentation_link,omitempty"`   // Optional link
+	Impact             *string    `json:"impact,omitempty"`               // Impact statement of the update
+	ImpactPortableText *string    `json:"impact_portable_text,omitempty"` // Impact statement in portable text format
+	StartAfter         *string    `json:"start_after,omitempty"`          // The earliest time the update will be automatically applied
+	StartAt            *time.Time `json:"start_at,omitempty"`             // The time when the update will be automatically applied
 }
 type UsageType string
 

--- a/handler/serviceuser/serviceuser.go
+++ b/handler/serviceuser/serviceuser.go
@@ -634,10 +634,13 @@ func UnitTypeChoices() []string {
 }
 
 type UpdateOut struct {
-	Deadline    *string    `json:"deadline,omitempty"`    // Deadline for installing the update
-	Description *string    `json:"description,omitempty"` // Description of the update
-	StartAfter  *string    `json:"start_after,omitempty"` // The earliest time the update will be automatically applied
-	StartAt     *time.Time `json:"start_at,omitempty"`    // The time when the update will be automatically applied
+	Deadline           *string    `json:"deadline,omitempty"`             // Deadline for installing the update
+	Description        *string    `json:"description,omitempty"`          // Description of the update
+	DocumentationLink  *string    `json:"documentation_link,omitempty"`   // Optional link
+	Impact             *string    `json:"impact,omitempty"`               // Impact statement of the update
+	ImpactPortableText *string    `json:"impact_portable_text,omitempty"` // Impact statement in portable text format
+	StartAfter         *string    `json:"start_after,omitempty"`          // The earliest time the update will be automatically applied
+	StartAt            *time.Time `json:"start_at,omitempty"`             // The time when the update will be automatically applied
 }
 type UsageType string
 


### PR DESCRIPTION
## About this change - What it does

Add service plan APIs to generated client.

* https://api.aiven.io/doc/#tag/Project/operation/ProjectServicePlanList
* https://api.aiven.io/doc/#tag/Project/operation/ProjectServicePlanPriceGet
* https://api.aiven.io/doc/#tag/Project/operation/ProjectServicePlanSpecsGet
* https://api.aiven.io/doc/#tag/Project/operation/ProjectServiceTypesGet
* https://api.aiven.io/doc/#tag/Project/operation/ProjectServiceTypesList

## Why this way

Makes it possible to address the following fixme comments:

* https://github.com/aiven/terraform-provider-aiven/blob/a76a6b5aff9627df49b100c61c48be9e3551a4b9/internal/schemautil/helpers.go#L95
* https://github.com/aiven/terraform-provider-aiven/blob/a76a6b5aff9627df49b100c61c48be9e3551a4b9/internal/schemautil/helpers.go#L108

... as well as migrate go-api-schemas to fetch service types with generated client:

* https://github.com/aiven/go-api-schemas/blob/1f6505d7ba7a2ab3c2fce25bae5d2881a5c23dde/internal/gen/gen.go#L37
