### PR TITLE
feat: add check to detect duplicate endpoints in config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -292,7 +292,6 @@ Service:
   - ServiceTaskCreate
   - ServiceTaskGet
   - ServiceUpdate
-  - ServiceUpdate
 ServiceUser:
   - ServiceUserCreate
   - ServiceUserCredentialsModify

--- a/generator/config_check.go
+++ b/generator/config_check.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+)
+
+func checkDuplicateEndpoints(config map[string][]string) error {
+	endpoints := make(map[string]struct{})
+	duplicates := make(map[string]struct{})
+
+	for _, methods := range config {
+		for _, method := range methods {
+			if _, exists := endpoints[method]; exists {
+				duplicates[method] = struct{}{}
+			} else {
+				endpoints[method] = struct{}{}
+			}
+		}
+	}
+
+	if len(duplicates) > 0 {
+		return fmt.Errorf("Duplicate endpoints found in config: %v", keys(duplicates))
+	}
+	return nil
+}
+
+func keys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/generator/main.go
+++ b/generator/main.go
@@ -82,6 +82,12 @@ func exec() error {
 		return err
 	}
 
+	// Check for duplicate endpoints
+	err = checkDuplicateEndpoints(config)
+	if err != nil {
+		return err
+	}
+
 	// Reads OpenAPI file and applies a patch
 	docBytes, err := readOpenAPIPatched(cfg.OpenAPIFile, cfg.OpenAPIPatchFile)
 	if err != nil {


### PR DESCRIPTION
## About this change - What it does

Adds a custom trunk check that detects duplicate endpoints in config.yaml.

The check looks like this:

```bash
❯ task generate
task: [get-openapi-spec] curl -s -o openapi.json https://api.aiven.io/doc/openapi.json
task: [go-generate] rm -rf handler
task: [go-generate] GEN_OUT_DIR=handler go run -tags=generator ./generator/...
2024-10-04T15:45:13+03:00 ERR error="Duplicate endpoints found in config: [AccountUsersSearch]"
task: [fmt-imports] find . -type f -name '*.go' -exec sed -zi 's/(?<== `\s+)"\n\+\t"/"\n"/g' {} +
task: [fmt-imports] goimports -local "github.com/aiven/go-client-codegen" -w .
```

## Why this way

Cleaner config
