### PR TITLE
feat: close previous update PRs when a new one is generated

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -22,20 +22,34 @@ jobs:
           go-version-file: go.mod
       - run: go install golang.org/x/tools/cmd/goimports@latest
       - uses: arduino/setup-task@v2
-      - run: wget -O openapi.json https://api.aiven.io/doc/openapi.json
       - run: task generate
         env:
           AIVEN_TOKEN: ${{ secrets.AIVEN_TOKEN }}
           AIVEN_PROJECT_NAME: ${{ secrets.AIVEN_PROJECT_NAME }}
       - id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-      - uses: peter-evans/create-pull-request@v7
+      - id: create_pr
+        uses: peter-evans/create-pull-request@v7
         with:
           author: GitHub <noreply@github.com>
           body: >
             automated changes by
             [update](https://github.com/aiven/go-client-codegen/blob/main/.github/workflows/update.yml)
             GitHub Actions workflow
-          branch: update/${{ steps.date.outputs.date }}
+          branch: update/${{ steps.date.outputs.date }}-${{ github.run_id }}
           commit-message: "chore(update): bump openapi schema (${{ steps.date.outputs.date }})"
           title: "chore(update): bump openapi schema (${{ steps.date.outputs.date }})"
+          labels: |
+            schema bump
+            automated pr
+      - name: Close previous update PRs
+        run: |
+          new_pr_number=${{ steps.create_pr.outputs.pull-request-number }}
+          prs=$(gh pr list --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("update/")) | .number')
+          for pr in $prs; do
+            if [ "$pr" != "$new_pr_number" ]; then
+              gh pr close $pr --comment "Auto-closing pull request in favor of #$new_pr_number" --delete-branch
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## About this change - What it does

Close previous PRs created by this workflow when a new one is created. Example [run](https://github.com/aiven/go-client-codegen/actions/runs/11028894847/job/30630083426):

```
Run new_pr_number=148
  
✓ Closed pull request aiven/go-client-codegen#147 (chore(update): bump openapi schema (2024-09-25))
! Skipped deleting the local branch since current directory is not a git repository 
✓ Deleted branch update/2024-09-25
```

Comment is added to the previous PR referencing the new PR: https://github.com/aiven/go-client-codegen/pull/147#issuecomment-2373361346

PR list before:

![go-client-codegen-PRs-before](https://github.com/user-attachments/assets/9975804e-96ee-4f8f-a550-d5e24f8dee1c)

PR list after:

![go-client-codegen-PRs-after](https://github.com/user-attachments/assets/18b9e832-d3c1-4010-a779-bdb67e501e87)


## Why this way

The action is ran every day on a cron schedule, and if the update from yesterday wasn't merged, we'd have two PRs open. The previous one would have to be closed manually.