### PR TITLE
fix: attempt to close previous PRs only if a new one was created

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -43,6 +43,7 @@ jobs:
             schema bump
             automated pr
       - name: Close previous update PRs
+        if: steps.create_pr.outputs.pull-request-operation == 'created'
         run: |
           new_pr_number=${{ steps.create_pr.outputs.pull-request-number }}
           prs=$(gh pr list --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("update/")) | .number')


### PR DESCRIPTION
Same as https://github.com/aiven/go-api-schemas/pull/220

See: https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#action-outputs
