### PR TITLE
fix: return response body on error status code

### DIFF
--- a/error.go
+++ b/error.go
@@ -23,16 +23,19 @@ type Error struct {
 
 // Error concatenates all the fields.
 func (e Error) Error() string {
-	var errMerged []byte
-	var err error
-	errMerged, err = json.Marshal(e.Errors)
+	// Must not use `%q` here which will escape every quote in the string,
+	// which might break external substring checks
+	msg := fmt.Sprintf(`[%d %s]: %s`, e.Status, e.OperationID, e.Message)
+	if e.Errors == nil {
+		return msg
+	}
+
+	errMerged, err := json.Marshal(e.Errors)
 	if err != nil {
 		errMerged = []byte(err.Error())
 	}
 
-	// Must not use `%q` here which will escape every quote in the string.
-	// It might break external substring checks
-	return fmt.Sprintf(`[%d %s]: %s: %s`, e.Status, e.OperationID, e.Message, errMerged)
+	return fmt.Sprintf(`%s: %s`, msg, errMerged)
 }
 
 // IsNotFound returns true if the specified error has status 404

--- a/error_test.go
+++ b/error_test.go
@@ -159,7 +159,7 @@ func TestFromResponse(t *testing.T) {
 			statusCode:     http.StatusInternalServerError,
 			body:           []byte(`unknown error`),
 			expectBytes:    nil,
-			expectStringer: `[500 UserAuth]: unknown error: null`,
+			expectStringer: `[500 UserAuth]: unknown error`,
 			expectErr: Error{
 				OperationID: "UserAuth",
 				Message:     "unknown error",
@@ -171,7 +171,7 @@ func TestFromResponse(t *testing.T) {
 			operationID:    "UserAuth",
 			statusCode:     http.StatusBadRequest,
 			body:           []byte(`{"message": {"key": "value"}}`), // message is not string
-			expectStringer: `[400 UserAuth]: json: cannot unmarshal object into Go struct field Error.message of type string: null`,
+			expectStringer: `[400 UserAuth]: json: cannot unmarshal object into Go struct field Error.message of type string`,
 			expectBytes:    nil,
 			expectErr: Error{
 				OperationID: "UserAuth",

--- a/option.go
+++ b/option.go
@@ -1,6 +1,8 @@
 // Package aiven provides a client for interacting with the Aiven API.
 package aiven
 
+import "time"
+
 // Option is a function that configures the client.
 type Option func(*aivenClient)
 
@@ -37,5 +39,26 @@ func HostOpt(host string) Option {
 func DoerOpt(doer Doer) Option {
 	return func(d *aivenClient) {
 		d.doer = doer
+	}
+}
+
+// RetryMaxOpt sets the maximum number of retries
+func RetryMaxOpt(retryMax int) Option {
+	return func(d *aivenClient) {
+		d.RetryMax = retryMax
+	}
+}
+
+// RetryWaitMinOpt sets the minimum wait time between retries
+func RetryWaitMinOpt(retryWaitMin time.Duration) Option {
+	return func(d *aivenClient) {
+		d.RetryWaitMin = retryWaitMin
+	}
+}
+
+// RetryWaitMaxOpt sets the maximum wait time between retries
+func RetryWaitMaxOpt(retryWaitMax time.Duration) Option {
+	return func(d *aivenClient) {
+		d.RetryWaitMax = retryWaitMax
 	}
 }


### PR DESCRIPTION
Uses retryablehttp.PassthroughErrorHandler to return response body as an error. By default retryablehttp returns attempts information instead.