### PR TITLE
feat: do not duplicate error message

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -134,14 +134,14 @@ func TestServiceCreateErrorsRetries(t *testing.T) {
 		{
 			Name:         "with errors field, list",
 			ResponseBody: `{"message": "Something went wrong", "errors": ["oh!", "no!"]}`,
-			ErrorExpect:  `[500 ServiceCreate]: Something went wrong: ["oh!","no!"]`,
+			ErrorExpect:  `[500 ServiceCreate]: Something went wrong (["oh!","no!"])`,
 			RetryMax:     1,
 			CallsExpect:  2,
 		},
 		{
 			Name:         "with errors field, string",
 			ResponseBody: `{"message": "Something went wrong", "errors": "wow!"}`,
-			ErrorExpect:  `[500 ServiceCreate]: Something went wrong: "wow!"`,
+			ErrorExpect:  `[500 ServiceCreate]: Something went wrong ("wow!")`,
 			RetryMax:     1,
 			CallsExpect:  2,
 		},

--- a/error_test.go
+++ b/error_test.go
@@ -132,7 +132,7 @@ func TestFromResponse(t *testing.T) {
 				}
 			  ]
 			}`),
-			expectStringer: `[404 UserAuth]: Account does not exist: [{"error_code":"account_not_found","message":"Account does not exist","status":404}]`,
+			expectStringer: `[404 UserAuth]: Account does not exist`,
 			expectBytes:    nil,
 			expectErr: Error{
 				Message: "Account does not exist",
@@ -177,6 +177,33 @@ func TestFromResponse(t *testing.T) {
 				OperationID: "UserAuth",
 				Message:     "json: cannot unmarshal object into Go struct field Error.message of type string",
 				Status:      http.StatusBadRequest,
+			},
+		},
+		{
+			name:        "add errors, because message is different",
+			operationID: "UserAuth",
+			statusCode:  http.StatusNotFound,
+			body: []byte(`{
+			  "message": "Oh no!",
+			  "errors": [
+				{
+				  "error_code": "account_not_found",
+				  "message": "Account does not exist",
+				  "status": 404
+				}
+			  ]
+			}`),
+			expectStringer: `[404 UserAuth]: Oh no! ([{"error_code":"account_not_found","message":"Account does not exist","status":404}])`,
+			expectBytes:    nil,
+			expectErr: Error{
+				Message: "Oh no!",
+				Errors: []any{map[string]any{
+					"error_code": "account_not_found",
+					"message":    "Account does not exist",
+					"status":     float64(404),
+				}},
+				OperationID: "UserAuth",
+				Status:      http.StatusNotFound,
 			},
 		},
 	}


### PR DESCRIPTION
Usually we get errors like this, and the message is just duplicated:

```
Error: error creating a service: [400 ServiceCreate]: Service 'foo' version '1.8' has reached end of availability and cannot be created: [{"message":"Service 'foo' version '1.8' has reached end of availability and cannot be created","status":400}]
```