### PR TITLE
fix: CompanyName accepts null values

### DIFF
--- a/handler/organization/organization.go
+++ b/handler/organization/organization.go
@@ -380,7 +380,7 @@ type OrganizationAddressGetOut struct {
 type OrganizationAddressUpdateIn struct {
 	AddressLines *[]string `json:"address_lines,omitempty"` // Address Lines
 	City         *string   `json:"city,omitempty"`
-	CompanyName  *string   `json:"company_name,omitempty"` // Name of a company
+	CompanyName  *string   `json:"company_name"`           // Name of a company
 	CountryCode  *string   `json:"country_code,omitempty"` // Country Code
 	State        *string   `json:"state,omitempty"`
 	ZipCode      *string   `json:"zip_code,omitempty"` // Zip Code

--- a/openapi_patch.yaml
+++ b/openapi_patch.yaml
@@ -15,6 +15,10 @@ paths:
 
 components:
   schemas:
+    OrganizationAddressUpdateRequestBody:
+      properties:
+        company_name:
+          nullable: true
     OrganizationVpcGetResponse:
       properties:
         peering_connections:


### PR DESCRIPTION
To reset `CompanyName` go client must send `null`.