### PR TITLE
refactor: remove `ServiceInfluxDBStats` handler

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -336,7 +336,6 @@ Service:
   - ServiceEnableWrites
   - ServiceGet
   - ServiceGetMigrationStatus
-  - ServiceInfluxDBStats
   - ServiceIntegrationCreate
   - ServiceIntegrationDelete
   - ServiceIntegrationEndpointCreate


### PR DESCRIPTION
Resolves NEX-1898.

The handler is no longer available.

