### PR TITLE
feat(upgradepipeline): add upgrade pipeline step operations

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -376,6 +376,13 @@ StaticIP:
   - StaticIPList
 Thanos:
   - ServiceThanosStorageSummary
+UpgradePipeline:
+  - UpgradePipelineStepCreate
+  - UpgradePipelineStepDelete
+  - UpgradePipelineStepGet
+  - UpgradePipelineStepList
+  - UpgradePipelineStepUpdate
+  - UpgradePipelineStepValidate
 User:
   - AccessTokenCreate
   - AccessTokenList

--- a/openapi_patch.yaml
+++ b/openapi_patch.yaml
@@ -429,3 +429,7 @@ components:
       schema:
         type: boolean
       required: false
+    # Avoid generating a single-value enum from the example UUID.
+    step_id:
+      schema:
+        enum: []


### PR DESCRIPTION
Resolves: NEX-2500

Add Upgrade Pipeline step operations. Patch `step_id` to stay a plain string until the OpenAPI schema is fixed upstream.