### PR TITLE
feat(privatelink): add Google PrivateLink operations

### DIFF
--- a/client_mock.go
+++ b/client_mock.go
@@ -22986,6 +22986,451 @@ func (_c *MockClient_ServicePrivatelinkAzureUpdate_Call) RunAndReturn(run func(c
 	return _c
 }
 
+// ServicePrivatelinkGoogleConnectionCreate provides a mock function for the type MockClient
+func (_mock *MockClient) ServicePrivatelinkGoogleConnectionCreate(ctx context.Context, project1 string, serviceName string, privatelinkConnectionId string, in *privatelink.ServicePrivatelinkGoogleConnectionCreateIn) (*privatelink.ServicePrivatelinkGoogleConnectionCreateOut, error) {
+	ret := _mock.Called(ctx, project1, serviceName, privatelinkConnectionId, in)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ServicePrivatelinkGoogleConnectionCreate")
+	}
+
+	var r0 *privatelink.ServicePrivatelinkGoogleConnectionCreateOut
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, *privatelink.ServicePrivatelinkGoogleConnectionCreateIn) (*privatelink.ServicePrivatelinkGoogleConnectionCreateOut, error)); ok {
+		return returnFunc(ctx, project1, serviceName, privatelinkConnectionId, in)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, *privatelink.ServicePrivatelinkGoogleConnectionCreateIn) *privatelink.ServicePrivatelinkGoogleConnectionCreateOut); ok {
+		r0 = returnFunc(ctx, project1, serviceName, privatelinkConnectionId, in)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*privatelink.ServicePrivatelinkGoogleConnectionCreateOut)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, *privatelink.ServicePrivatelinkGoogleConnectionCreateIn) error); ok {
+		r1 = returnFunc(ctx, project1, serviceName, privatelinkConnectionId, in)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_ServicePrivatelinkGoogleConnectionCreate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ServicePrivatelinkGoogleConnectionCreate'
+type MockClient_ServicePrivatelinkGoogleConnectionCreate_Call struct {
+	*mock.Call
+}
+
+// ServicePrivatelinkGoogleConnectionCreate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - project1 string
+//   - serviceName string
+//   - privatelinkConnectionId string
+//   - in *privatelink.ServicePrivatelinkGoogleConnectionCreateIn
+func (_e *MockClient_Expecter) ServicePrivatelinkGoogleConnectionCreate(ctx interface{}, project1 interface{}, serviceName interface{}, privatelinkConnectionId interface{}, in interface{}) *MockClient_ServicePrivatelinkGoogleConnectionCreate_Call {
+	return &MockClient_ServicePrivatelinkGoogleConnectionCreate_Call{Call: _e.mock.On("ServicePrivatelinkGoogleConnectionCreate", ctx, project1, serviceName, privatelinkConnectionId, in)}
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleConnectionCreate_Call) Run(run func(ctx context.Context, project1 string, serviceName string, privatelinkConnectionId string, in *privatelink.ServicePrivatelinkGoogleConnectionCreateIn)) *MockClient_ServicePrivatelinkGoogleConnectionCreate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		var arg4 *privatelink.ServicePrivatelinkGoogleConnectionCreateIn
+		if args[4] != nil {
+			arg4 = args[4].(*privatelink.ServicePrivatelinkGoogleConnectionCreateIn)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleConnectionCreate_Call) Return(servicePrivatelinkGoogleConnectionCreateOut *privatelink.ServicePrivatelinkGoogleConnectionCreateOut, err error) *MockClient_ServicePrivatelinkGoogleConnectionCreate_Call {
+	_c.Call.Return(servicePrivatelinkGoogleConnectionCreateOut, err)
+	return _c
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleConnectionCreate_Call) RunAndReturn(run func(ctx context.Context, project1 string, serviceName string, privatelinkConnectionId string, in *privatelink.ServicePrivatelinkGoogleConnectionCreateIn) (*privatelink.ServicePrivatelinkGoogleConnectionCreateOut, error)) *MockClient_ServicePrivatelinkGoogleConnectionCreate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ServicePrivatelinkGoogleConnectionList provides a mock function for the type MockClient
+func (_mock *MockClient) ServicePrivatelinkGoogleConnectionList(ctx context.Context, project1 string, serviceName string) ([]privatelink.ServicePrivatelinkGoogleConnectionListOut, error) {
+	ret := _mock.Called(ctx, project1, serviceName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ServicePrivatelinkGoogleConnectionList")
+	}
+
+	var r0 []privatelink.ServicePrivatelinkGoogleConnectionListOut
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]privatelink.ServicePrivatelinkGoogleConnectionListOut, error)); ok {
+		return returnFunc(ctx, project1, serviceName)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []privatelink.ServicePrivatelinkGoogleConnectionListOut); ok {
+		r0 = returnFunc(ctx, project1, serviceName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]privatelink.ServicePrivatelinkGoogleConnectionListOut)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, project1, serviceName)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_ServicePrivatelinkGoogleConnectionList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ServicePrivatelinkGoogleConnectionList'
+type MockClient_ServicePrivatelinkGoogleConnectionList_Call struct {
+	*mock.Call
+}
+
+// ServicePrivatelinkGoogleConnectionList is a helper method to define mock.On call
+//   - ctx context.Context
+//   - project1 string
+//   - serviceName string
+func (_e *MockClient_Expecter) ServicePrivatelinkGoogleConnectionList(ctx interface{}, project1 interface{}, serviceName interface{}) *MockClient_ServicePrivatelinkGoogleConnectionList_Call {
+	return &MockClient_ServicePrivatelinkGoogleConnectionList_Call{Call: _e.mock.On("ServicePrivatelinkGoogleConnectionList", ctx, project1, serviceName)}
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleConnectionList_Call) Run(run func(ctx context.Context, project1 string, serviceName string)) *MockClient_ServicePrivatelinkGoogleConnectionList_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleConnectionList_Call) Return(servicePrivatelinkGoogleConnectionListOuts []privatelink.ServicePrivatelinkGoogleConnectionListOut, err error) *MockClient_ServicePrivatelinkGoogleConnectionList_Call {
+	_c.Call.Return(servicePrivatelinkGoogleConnectionListOuts, err)
+	return _c
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleConnectionList_Call) RunAndReturn(run func(ctx context.Context, project1 string, serviceName string) ([]privatelink.ServicePrivatelinkGoogleConnectionListOut, error)) *MockClient_ServicePrivatelinkGoogleConnectionList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ServicePrivatelinkGoogleCreate provides a mock function for the type MockClient
+func (_mock *MockClient) ServicePrivatelinkGoogleCreate(ctx context.Context, project1 string, serviceName string) (*privatelink.ServicePrivatelinkGoogleCreateOut, error) {
+	ret := _mock.Called(ctx, project1, serviceName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ServicePrivatelinkGoogleCreate")
+	}
+
+	var r0 *privatelink.ServicePrivatelinkGoogleCreateOut
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*privatelink.ServicePrivatelinkGoogleCreateOut, error)); ok {
+		return returnFunc(ctx, project1, serviceName)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *privatelink.ServicePrivatelinkGoogleCreateOut); ok {
+		r0 = returnFunc(ctx, project1, serviceName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*privatelink.ServicePrivatelinkGoogleCreateOut)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, project1, serviceName)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_ServicePrivatelinkGoogleCreate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ServicePrivatelinkGoogleCreate'
+type MockClient_ServicePrivatelinkGoogleCreate_Call struct {
+	*mock.Call
+}
+
+// ServicePrivatelinkGoogleCreate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - project1 string
+//   - serviceName string
+func (_e *MockClient_Expecter) ServicePrivatelinkGoogleCreate(ctx interface{}, project1 interface{}, serviceName interface{}) *MockClient_ServicePrivatelinkGoogleCreate_Call {
+	return &MockClient_ServicePrivatelinkGoogleCreate_Call{Call: _e.mock.On("ServicePrivatelinkGoogleCreate", ctx, project1, serviceName)}
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleCreate_Call) Run(run func(ctx context.Context, project1 string, serviceName string)) *MockClient_ServicePrivatelinkGoogleCreate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleCreate_Call) Return(servicePrivatelinkGoogleCreateOut *privatelink.ServicePrivatelinkGoogleCreateOut, err error) *MockClient_ServicePrivatelinkGoogleCreate_Call {
+	_c.Call.Return(servicePrivatelinkGoogleCreateOut, err)
+	return _c
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleCreate_Call) RunAndReturn(run func(ctx context.Context, project1 string, serviceName string) (*privatelink.ServicePrivatelinkGoogleCreateOut, error)) *MockClient_ServicePrivatelinkGoogleCreate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ServicePrivatelinkGoogleDelete provides a mock function for the type MockClient
+func (_mock *MockClient) ServicePrivatelinkGoogleDelete(ctx context.Context, project1 string, serviceName string) (*privatelink.ServicePrivatelinkGoogleDeleteOut, error) {
+	ret := _mock.Called(ctx, project1, serviceName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ServicePrivatelinkGoogleDelete")
+	}
+
+	var r0 *privatelink.ServicePrivatelinkGoogleDeleteOut
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*privatelink.ServicePrivatelinkGoogleDeleteOut, error)); ok {
+		return returnFunc(ctx, project1, serviceName)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *privatelink.ServicePrivatelinkGoogleDeleteOut); ok {
+		r0 = returnFunc(ctx, project1, serviceName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*privatelink.ServicePrivatelinkGoogleDeleteOut)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, project1, serviceName)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_ServicePrivatelinkGoogleDelete_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ServicePrivatelinkGoogleDelete'
+type MockClient_ServicePrivatelinkGoogleDelete_Call struct {
+	*mock.Call
+}
+
+// ServicePrivatelinkGoogleDelete is a helper method to define mock.On call
+//   - ctx context.Context
+//   - project1 string
+//   - serviceName string
+func (_e *MockClient_Expecter) ServicePrivatelinkGoogleDelete(ctx interface{}, project1 interface{}, serviceName interface{}) *MockClient_ServicePrivatelinkGoogleDelete_Call {
+	return &MockClient_ServicePrivatelinkGoogleDelete_Call{Call: _e.mock.On("ServicePrivatelinkGoogleDelete", ctx, project1, serviceName)}
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleDelete_Call) Run(run func(ctx context.Context, project1 string, serviceName string)) *MockClient_ServicePrivatelinkGoogleDelete_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleDelete_Call) Return(servicePrivatelinkGoogleDeleteOut *privatelink.ServicePrivatelinkGoogleDeleteOut, err error) *MockClient_ServicePrivatelinkGoogleDelete_Call {
+	_c.Call.Return(servicePrivatelinkGoogleDeleteOut, err)
+	return _c
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleDelete_Call) RunAndReturn(run func(ctx context.Context, project1 string, serviceName string) (*privatelink.ServicePrivatelinkGoogleDeleteOut, error)) *MockClient_ServicePrivatelinkGoogleDelete_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ServicePrivatelinkGoogleGet provides a mock function for the type MockClient
+func (_mock *MockClient) ServicePrivatelinkGoogleGet(ctx context.Context, project1 string, serviceName string) (*privatelink.ServicePrivatelinkGoogleGetOut, error) {
+	ret := _mock.Called(ctx, project1, serviceName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ServicePrivatelinkGoogleGet")
+	}
+
+	var r0 *privatelink.ServicePrivatelinkGoogleGetOut
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*privatelink.ServicePrivatelinkGoogleGetOut, error)); ok {
+		return returnFunc(ctx, project1, serviceName)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *privatelink.ServicePrivatelinkGoogleGetOut); ok {
+		r0 = returnFunc(ctx, project1, serviceName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*privatelink.ServicePrivatelinkGoogleGetOut)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, project1, serviceName)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_ServicePrivatelinkGoogleGet_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ServicePrivatelinkGoogleGet'
+type MockClient_ServicePrivatelinkGoogleGet_Call struct {
+	*mock.Call
+}
+
+// ServicePrivatelinkGoogleGet is a helper method to define mock.On call
+//   - ctx context.Context
+//   - project1 string
+//   - serviceName string
+func (_e *MockClient_Expecter) ServicePrivatelinkGoogleGet(ctx interface{}, project1 interface{}, serviceName interface{}) *MockClient_ServicePrivatelinkGoogleGet_Call {
+	return &MockClient_ServicePrivatelinkGoogleGet_Call{Call: _e.mock.On("ServicePrivatelinkGoogleGet", ctx, project1, serviceName)}
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleGet_Call) Run(run func(ctx context.Context, project1 string, serviceName string)) *MockClient_ServicePrivatelinkGoogleGet_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleGet_Call) Return(servicePrivatelinkGoogleGetOut *privatelink.ServicePrivatelinkGoogleGetOut, err error) *MockClient_ServicePrivatelinkGoogleGet_Call {
+	_c.Call.Return(servicePrivatelinkGoogleGetOut, err)
+	return _c
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleGet_Call) RunAndReturn(run func(ctx context.Context, project1 string, serviceName string) (*privatelink.ServicePrivatelinkGoogleGetOut, error)) *MockClient_ServicePrivatelinkGoogleGet_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ServicePrivatelinkGoogleRefresh provides a mock function for the type MockClient
+func (_mock *MockClient) ServicePrivatelinkGoogleRefresh(ctx context.Context, project1 string, serviceName string) error {
+	ret := _mock.Called(ctx, project1, serviceName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ServicePrivatelinkGoogleRefresh")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = returnFunc(ctx, project1, serviceName)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockClient_ServicePrivatelinkGoogleRefresh_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ServicePrivatelinkGoogleRefresh'
+type MockClient_ServicePrivatelinkGoogleRefresh_Call struct {
+	*mock.Call
+}
+
+// ServicePrivatelinkGoogleRefresh is a helper method to define mock.On call
+//   - ctx context.Context
+//   - project1 string
+//   - serviceName string
+func (_e *MockClient_Expecter) ServicePrivatelinkGoogleRefresh(ctx interface{}, project1 interface{}, serviceName interface{}) *MockClient_ServicePrivatelinkGoogleRefresh_Call {
+	return &MockClient_ServicePrivatelinkGoogleRefresh_Call{Call: _e.mock.On("ServicePrivatelinkGoogleRefresh", ctx, project1, serviceName)}
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleRefresh_Call) Run(run func(ctx context.Context, project1 string, serviceName string)) *MockClient_ServicePrivatelinkGoogleRefresh_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleRefresh_Call) Return(err error) *MockClient_ServicePrivatelinkGoogleRefresh_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockClient_ServicePrivatelinkGoogleRefresh_Call) RunAndReturn(run func(ctx context.Context, project1 string, serviceName string) error) *MockClient_ServicePrivatelinkGoogleRefresh_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ServiceQueryActivity provides a mock function for the type MockClient
 func (_mock *MockClient) ServiceQueryActivity(ctx context.Context, project1 string, serviceName string, in *service.ServiceQueryActivityIn) ([]service.QueryOut, error) {
 	ret := _mock.Called(ctx, project1, serviceName, in)

--- a/config.yaml
+++ b/config.yaml
@@ -288,6 +288,12 @@ Privatelink:
   - ServicePrivatelinkAzureDelete
   - ServicePrivatelinkAzureGet
   - ServicePrivatelinkAzureUpdate
+  - ServicePrivatelinkGoogleConnectionCreate
+  - ServicePrivatelinkGoogleConnectionList
+  - ServicePrivatelinkGoogleCreate
+  - ServicePrivatelinkGoogleDelete
+  - ServicePrivatelinkGoogleGet
+  - ServicePrivatelinkGoogleRefresh
 Project:
   - ListProjectVpcPeeringConnectionTypes
   - ProjectAlertsList

--- a/handler/privatelink/privatelink.go
+++ b/handler/privatelink/privatelink.go
@@ -86,6 +86,42 @@ type Handler interface {
 	// https://api.aiven.io/doc/#tag/Service/operation/ServicePrivatelinkAzureUpdate
 	// Required roles or permissions: service:configuration:write
 	ServicePrivatelinkAzureUpdate(ctx context.Context, project string, serviceName string, in *ServicePrivatelinkAzureUpdateIn) (*ServicePrivatelinkAzureUpdateOut, error)
+
+	// ServicePrivatelinkGoogleConnectionCreate approve a new Google Private Service Connect connection
+	// POST /v1/project/{project}/service/{service_name}/privatelink/google/connections/{privatelink_connection_id}/approve
+	// https://api.aiven.io/doc/#tag/Service/operation/ServicePrivatelinkGoogleConnectionCreate
+	// Required roles or permissions: service:configuration:write
+	ServicePrivatelinkGoogleConnectionCreate(ctx context.Context, project string, serviceName string, privatelinkConnectionId string, in *ServicePrivatelinkGoogleConnectionCreateIn) (*ServicePrivatelinkGoogleConnectionCreateOut, error)
+
+	// ServicePrivatelinkGoogleConnectionList list Google Private Service Connect connections for a service
+	// GET /v1/project/{project}/service/{service_name}/privatelink/google/connections
+	// https://api.aiven.io/doc/#tag/Service/operation/ServicePrivatelinkGoogleConnectionList
+	// Required roles or permissions: service:configuration:write
+	ServicePrivatelinkGoogleConnectionList(ctx context.Context, project string, serviceName string) ([]ServicePrivatelinkGoogleConnectionListOut, error)
+
+	// ServicePrivatelinkGoogleCreate create a Google Private Service Connect endpoint for a service
+	// POST /v1/project/{project}/service/{service_name}/privatelink/google
+	// https://api.aiven.io/doc/#tag/Service/operation/ServicePrivatelinkGoogleCreate
+	// Required roles or permissions: service:configuration:write
+	ServicePrivatelinkGoogleCreate(ctx context.Context, project string, serviceName string) (*ServicePrivatelinkGoogleCreateOut, error)
+
+	// ServicePrivatelinkGoogleDelete delete a Google Private Service Connect endpoint for a service
+	// DELETE /v1/project/{project}/service/{service_name}/privatelink/google
+	// https://api.aiven.io/doc/#tag/Service/operation/ServicePrivatelinkGoogleDelete
+	// Required roles or permissions: service:configuration:write
+	ServicePrivatelinkGoogleDelete(ctx context.Context, project string, serviceName string) (*ServicePrivatelinkGoogleDeleteOut, error)
+
+	// ServicePrivatelinkGoogleGet return status of Google Private Service Connect endpoint
+	// GET /v1/project/{project}/service/{service_name}/privatelink/google
+	// https://api.aiven.io/doc/#tag/Service/operation/ServicePrivatelinkGoogleGet
+	// Required roles or permissions: service:configuration:write
+	ServicePrivatelinkGoogleGet(ctx context.Context, project string, serviceName string) (*ServicePrivatelinkGoogleGetOut, error)
+
+	// ServicePrivatelinkGoogleRefresh initiate fetch from cloud & update to aiven DB of connections to this privatelink
+	// POST /v1/project/{project}/service/{service_name}/privatelink/google/refresh
+	// https://api.aiven.io/doc/#tag/Service/operation/ServicePrivatelinkGoogleRefresh
+	// Required roles or permissions: service:configuration:write
+	ServicePrivatelinkGoogleRefresh(ctx context.Context, project string, serviceName string) error
 }
 
 // doer http client
@@ -270,6 +306,76 @@ func (h *PrivatelinkHandler) ServicePrivatelinkAzureUpdate(ctx context.Context, 
 	}
 	return out, nil
 }
+func (h *PrivatelinkHandler) ServicePrivatelinkGoogleConnectionCreate(ctx context.Context, project string, serviceName string, privatelinkConnectionId string, in *ServicePrivatelinkGoogleConnectionCreateIn) (*ServicePrivatelinkGoogleConnectionCreateOut, error) {
+	path := fmt.Sprintf("/v1/project/%s/service/%s/privatelink/google/connections/%s/approve", url.PathEscape(project), url.PathEscape(serviceName), url.PathEscape(privatelinkConnectionId))
+	b, err := h.doer.Do(ctx, "ServicePrivatelinkGoogleConnectionCreate", "POST", path, in)
+	if err != nil {
+		return nil, err
+	}
+	out := new(ServicePrivatelinkGoogleConnectionCreateOut)
+	err = json.Unmarshal(b, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+func (h *PrivatelinkHandler) ServicePrivatelinkGoogleConnectionList(ctx context.Context, project string, serviceName string) ([]ServicePrivatelinkGoogleConnectionListOut, error) {
+	path := fmt.Sprintf("/v1/project/%s/service/%s/privatelink/google/connections", url.PathEscape(project), url.PathEscape(serviceName))
+	b, err := h.doer.Do(ctx, "ServicePrivatelinkGoogleConnectionList", "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	out := new(servicePrivatelinkGoogleConnectionListOut)
+	err = json.Unmarshal(b, out)
+	if err != nil {
+		return nil, err
+	}
+	return out.Connections, nil
+}
+func (h *PrivatelinkHandler) ServicePrivatelinkGoogleCreate(ctx context.Context, project string, serviceName string) (*ServicePrivatelinkGoogleCreateOut, error) {
+	path := fmt.Sprintf("/v1/project/%s/service/%s/privatelink/google", url.PathEscape(project), url.PathEscape(serviceName))
+	b, err := h.doer.Do(ctx, "ServicePrivatelinkGoogleCreate", "POST", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	out := new(ServicePrivatelinkGoogleCreateOut)
+	err = json.Unmarshal(b, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+func (h *PrivatelinkHandler) ServicePrivatelinkGoogleDelete(ctx context.Context, project string, serviceName string) (*ServicePrivatelinkGoogleDeleteOut, error) {
+	path := fmt.Sprintf("/v1/project/%s/service/%s/privatelink/google", url.PathEscape(project), url.PathEscape(serviceName))
+	b, err := h.doer.Do(ctx, "ServicePrivatelinkGoogleDelete", "DELETE", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	out := new(ServicePrivatelinkGoogleDeleteOut)
+	err = json.Unmarshal(b, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+func (h *PrivatelinkHandler) ServicePrivatelinkGoogleGet(ctx context.Context, project string, serviceName string) (*ServicePrivatelinkGoogleGetOut, error) {
+	path := fmt.Sprintf("/v1/project/%s/service/%s/privatelink/google", url.PathEscape(project), url.PathEscape(serviceName))
+	b, err := h.doer.Do(ctx, "ServicePrivatelinkGoogleGet", "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	out := new(ServicePrivatelinkGoogleGetOut)
+	err = json.Unmarshal(b, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+func (h *PrivatelinkHandler) ServicePrivatelinkGoogleRefresh(ctx context.Context, project string, serviceName string) error {
+	path := fmt.Sprintf("/v1/project/%s/service/%s/privatelink/google/refresh", url.PathEscape(project), url.PathEscape(serviceName))
+	_, err := h.doer.Do(ctx, "ServicePrivatelinkGoogleRefresh", "POST", path, nil)
+	return err
+}
 
 type ConnectionOut struct {
 	DnsName                 string              `json:"dns_name"`                            // The VPC Endpoint DNS name that the Aiven privatelink access route DNS name is using as the value for itsCNAME record. This DNS name resolves to the private IP addresses of the VPC Endpoint's NICs in all configured subnets
@@ -453,6 +559,66 @@ type ServicePrivatelinkAzureUpdateOut struct {
 	UserSubscriptionIds []string                         `json:"user_subscription_ids"`         // IDs of Azure subscriptions allowed to connect to the service
 }
 
+// ServicePrivatelinkGoogleConnectionCreateIn ServicePrivatelinkGoogleConnectionCreateRequestBody
+type ServicePrivatelinkGoogleConnectionCreateIn struct {
+	UserIPAddress string `json:"user_ip_address"` // (Private) IP address of Private Service Connect endpoint
+}
+
+// ServicePrivatelinkGoogleConnectionCreateOut ServicePrivatelinkGoogleConnectionCreateResponse
+type ServicePrivatelinkGoogleConnectionCreateOut struct {
+	PrivatelinkConnectionId string                                      `json:"privatelink_connection_id"` // Privatelink connection ID
+	PscConnectionId         string                                      `json:"psc_connection_id"`         // Google Private Service Connect connection ID for this connection
+	State                   ServicePrivatelinkGoogleConnectionStateType `json:"state"`                     // The Aiven connection state. The Google endpoint status has a separate value
+	UserIPAddress           string                                      `json:"user_ip_address"`           // Frontend IP address of the forwarding rule that connects to the service at customer end
+}
+type ServicePrivatelinkGoogleConnectionListOut struct {
+	PrivatelinkConnectionId string              `json:"privatelink_connection_id"` // Privatelink connection ID
+	PscConnectionId         string              `json:"psc_connection_id"`         // Google Private Service Connect connection ID for this connection
+	State                   ConnectionStateType `json:"state"`                     // The Aiven connection state. The Google endpoint status has a separate value
+	UserIPAddress           string              `json:"user_ip_address"`           // Frontend IP address of the forwarding rule that connects to the service at customer end
+}
+type ServicePrivatelinkGoogleConnectionStateType string
+
+const (
+	ServicePrivatelinkGoogleConnectionStateTypeActive              ServicePrivatelinkGoogleConnectionStateType = "active"
+	ServicePrivatelinkGoogleConnectionStateTypeConnected           ServicePrivatelinkGoogleConnectionStateType = "connected"
+	ServicePrivatelinkGoogleConnectionStateTypePendingUserApproval ServicePrivatelinkGoogleConnectionStateType = "pending-user-approval"
+	ServicePrivatelinkGoogleConnectionStateTypeUserApproved        ServicePrivatelinkGoogleConnectionStateType = "user-approved"
+)
+
+func ServicePrivatelinkGoogleConnectionStateTypeChoices() []string {
+	return []string{"active", "connected", "pending-user-approval", "user-approved"}
+}
+
+// ServicePrivatelinkGoogleCreateOut ServicePrivatelinkGoogleCreateResponse
+type ServicePrivatelinkGoogleCreateOut struct {
+	GoogleServiceAttachment string                            `json:"google_service_attachment"` // Google Private Service Connect service attachment name
+	State                   ServicePrivatelinkGoogleStateType `json:"state"`                     // Privatelink resource state
+}
+
+// ServicePrivatelinkGoogleDeleteOut ServicePrivatelinkGoogleDeleteResponse
+type ServicePrivatelinkGoogleDeleteOut struct {
+	GoogleServiceAttachment string                            `json:"google_service_attachment"` // Google Private Service Connect service attachment name
+	State                   ServicePrivatelinkGoogleStateType `json:"state"`                     // Privatelink resource state
+}
+
+// ServicePrivatelinkGoogleGetOut ServicePrivatelinkGoogleGetResponse
+type ServicePrivatelinkGoogleGetOut struct {
+	GoogleServiceAttachment string                            `json:"google_service_attachment"` // Google Private Service Connect service attachment name
+	State                   ServicePrivatelinkGoogleStateType `json:"state"`                     // Privatelink resource state
+}
+type ServicePrivatelinkGoogleStateType string
+
+const (
+	ServicePrivatelinkGoogleStateTypeActive   ServicePrivatelinkGoogleStateType = "active"
+	ServicePrivatelinkGoogleStateTypeCreating ServicePrivatelinkGoogleStateType = "creating"
+	ServicePrivatelinkGoogleStateTypeDeleting ServicePrivatelinkGoogleStateType = "deleting"
+)
+
+func ServicePrivatelinkGoogleStateTypeChoices() []string {
+	return []string{"active", "creating", "deleting"}
+}
+
 // publicPrivatelinkAvailabilityListOut PublicPrivatelinkAvailabilityListResponse
 type publicPrivatelinkAvailabilityListOut struct {
 	PrivatelinkAvailability []PrivatelinkAvailabilityOut `json:"privatelink_availability"` // Privatelink pricing information for supported clouds
@@ -466,4 +632,9 @@ type servicePrivatelinkAWSConnectionListOut struct {
 // servicePrivatelinkAzureConnectionListOut ServicePrivatelinkAzureConnectionListResponse
 type servicePrivatelinkAzureConnectionListOut struct {
 	Connections []ServicePrivatelinkAzureConnectionListOut `json:"connections"` // Private endpoint connection list
+}
+
+// servicePrivatelinkGoogleConnectionListOut ServicePrivatelinkGoogleConnectionListResponse
+type servicePrivatelinkGoogleConnectionListOut struct {
+	Connections []ServicePrivatelinkGoogleConnectionListOut `json:"connections"` // Private Service Connect endpoint connection list
 }

--- a/permissions.yaml
+++ b/permissions.yaml
@@ -503,6 +503,18 @@ ServicePrivatelinkAzureGet:
   - service:configuration:write
 ServicePrivatelinkAzureUpdate:
   - service:configuration:write
+ServicePrivatelinkGoogleConnectionCreate:
+  - service:configuration:write
+ServicePrivatelinkGoogleConnectionList:
+  - service:configuration:write
+ServicePrivatelinkGoogleCreate:
+  - service:configuration:write
+ServicePrivatelinkGoogleDelete:
+  - service:configuration:write
+ServicePrivatelinkGoogleGet:
+  - service:configuration:write
+ServicePrivatelinkGoogleRefresh:
+  - service:configuration:write
 ServiceQueryActivity:
   - developer
   - operator


### PR DESCRIPTION
Resolves: NEX-2679

Adds the GCP privatelink API. The legacy client (https://github.com/aiven/aiven-go-client/blob/main/gcp_privatelink.go#L43) sent an empty body for `ServicePrivatelinkGoogleCreate` as an API workaround. That requirement was removed three years ago, so the workaround is no longer needed.